### PR TITLE
Fix for building errors, removed scope operators

### DIFF
--- a/src/snap/proxy/collector_proxy.cc
+++ b/src/snap/proxy/collector_proxy.cc
@@ -50,7 +50,7 @@ CollectorImpl::~CollectorImpl() {
 Status CollectorImpl::CollectMetrics(ServerContext* context,
                                      const MetricsArg* req,
                                      MetricsReply* resp) {
-  std::vector<Metric::Metric> metrics;
+  std::vector<Metric> metrics;
   RepeatedPtrField<rpc::Metric> rpc_mets = req->metrics();
 
   for (int i = 0; i < rpc_mets.size(); i++) {
@@ -59,7 +59,7 @@ Status CollectorImpl::CollectMetrics(ServerContext* context,
 
   collector->collect_metrics(&metrics);
 
-  for (Metric::Metric met : metrics) {
+  for (Metric met : metrics) {
     *resp->add_metrics() = *met.rpc_metric_ptr;
   }
   return Status::OK;

--- a/src/snap/proxy/processor_proxy.cc
+++ b/src/snap/proxy/processor_proxy.cc
@@ -46,7 +46,7 @@ ProcessorImpl::~ProcessorImpl() {
 
 Status ProcessorImpl::Process(ServerContext* context, const PubProcArg* req,
                               MetricsReply* resp) {
-  std::vector<Metric::Metric> metrics;
+  std::vector<Metric> metrics;
   RepeatedPtrField<rpc::Metric> rpc_mets = req->metrics();
 
   for (int i = 0; i < rpc_mets.size(); i++) {
@@ -56,7 +56,7 @@ Status ProcessorImpl::Process(ServerContext* context, const PubProcArg* req,
   Plugin::Config config(req->config());
   processor->process_metrics(&metrics, config);
 
-  for (Metric::Metric met : metrics) {
+  for (Metric met : metrics) {
     *resp->add_metrics() = *met.rpc_metric_ptr;
   }
   return Status::OK;

--- a/src/snap/proxy/publisher_proxy.cc
+++ b/src/snap/proxy/publisher_proxy.cc
@@ -45,7 +45,7 @@ PublisherImpl::~PublisherImpl() {
 
 Status PublisherImpl::Publish(ServerContext* context, const PubProcArg* req,
                               ErrReply* resp) {
-  std::vector<Metric::Metric> metrics;
+  std::vector<Metric> metrics;
   RepeatedPtrField<rpc::Metric> rpc_mets = req->metrics();
 
   for (int i = 0; i < rpc_mets.size(); i++) {


### PR DESCRIPTION
Following errors were observed after calling `make`:

```
make
Making all in src
make[1]: Entering directory '/home/kzab/work/src/github.com/intelsdi-x/snap-plugin-lib-cpp/src'
/bin/bash ../libtool  --tag=CXX   --mode=compile g++ -DPACKAGE_NAME=\"Snap\ Plugin\ Library\" -DPACKAGE_TARNAME=\"snap\" -DPACKAGE_VERSION=\"0.0.1-beta\" -DPACKAGE_STRING=\"Snap\ Plugin\ Library\ 0.0.1-beta\" -DPACKAGE_BUGREPORT=\"danielscottt@gmail.com\" -DPACKAGE_URL=\"\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DPACKAGE=\"snap\" -DVERSION=\"0.0.1-beta\" -I.  --std=c++11 -I../include   -g -O2 -MT snap/proxy/libsnap_la-collector_proxy.lo -MD -MP -MF snap/proxy/.deps/libsnap_la-collector_proxy.Tpo -c -o snap/proxy/libsnap_la-collector_proxy.lo `test -f 'snap/proxy/collector_proxy.cc' || echo './'`snap/proxy/collector_proxy.cc
libtool: compile:  g++ "-DPACKAGE_NAME=\"Snap Plugin Library\"" -DPACKAGE_TARNAME=\"snap\" -DPACKAGE_VERSION=\"0.0.1-beta\" "-DPACKAGE_STRING=\"Snap Plugin Library 0.0.1-beta\"" -DPACKAGE_BUGREPORT=\"danielscottt@gmail.com\" -DPACKAGE_URL=\"\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DPACKAGE=\"snap\" -DVERSION=\"0.0.1-beta\" -I. --std=c++11 -I../include -g -O2 -MT snap/proxy/libsnap_la-collector_proxy.lo -MD -MP -MF snap/proxy/.deps/libsnap_la-collector_proxy.Tpo -c snap/proxy/collector_proxy.cc  -fPIC -DPIC -o snap/proxy/.libs/libsnap_la-collector_proxy.o
snap/proxy/collector_proxy.cc: In member function ‘virtual grpc::Status Plugin::Proxy::CollectorImpl::CollectMetrics(grpc::ServerContext*, const rpc::MetricsArg*, rpc::MetricsReply*)’:
snap/proxy/collector_proxy.cc:53:29: error: type/value mismatch at argument 1 in template parameter list for ‘template<class _Tp, class _Alloc> class std::vector’
   std::vector<Metric::Metric> metrics;
                             ^
snap/proxy/collector_proxy.cc:53:29: note:   expected a type, got ‘Plugin::Metric::Metric’
snap/proxy/collector_proxy.cc:53:29: error: template argument 2 is invalid
snap/proxy/collector_proxy.cc:57:13: error: request for member ‘emplace_back’ in ‘metrics’, which is of non-class type ‘int’
     metrics.emplace_back(rpc_mets.Mutable(i));
             ^~~~~~~~~~~~
snap/proxy/collector_proxy.cc:60:38: error: no matching function for call to ‘Plugin::CollectorInterface::collect_metrics(int*)’
   collector->collect_metrics(&metrics);
                                      ^
In file included from ./snap/proxy/plugin_proxy.h:20:0,
                 from ./snap/proxy/collector_proxy.h:21,
                 from snap/proxy/collector_proxy.cc:14:
./snap/plugin.h:115:16: note: candidate: virtual void Plugin::CollectorInterface::collect_metrics(std::vector<Plugin::Metric>*)
   virtual void collect_metrics(std::vector<Metric>* metrics) = 0;
                ^~~~~~~~~~~~~~~
./snap/plugin.h:115:16: note:   no known conversion for argument 1 from ‘int*’ to ‘std::vector<Plugin::Metric>*’
snap/proxy/collector_proxy.cc:62:8: error: ‘Plugin::Metric::Metric’ names the constructor, not the type
   for (Metric::Metric met : metrics) {
        ^~~~~~
snap/proxy/collector_proxy.cc:62:23: error: expected ‘;’ before ‘met’
   for (Metric::Metric met : metrics) {
                       ^~~
snap/proxy/collector_proxy.cc:64:3: error: statement cannot resolve address of overloaded function
   }
   ^
snap/proxy/collector_proxy.cc:65:3: error: expected primary-expression before ‘return’
   return Status::OK;
   ^~~~~~
snap/proxy/collector_proxy.cc:65:3: error: expected ‘;’ before ‘return’
snap/proxy/collector_proxy.cc:65:3: error: expected primary-expression before ‘return’
snap/proxy/collector_proxy.cc:65:3: error: expected ‘)’ before ‘return’
Makefile:540: recipe for target 'snap/proxy/libsnap_la-collector_proxy.lo' failed
make[1]: *** [snap/proxy/libsnap_la-collector_proxy.lo] Error 1
make[1]: Leaving directory '/home/kzab/work/src/github.com/intelsdi-x/snap-plugin-lib-cpp/src'
Makefile:377: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
```