### PR TITLE
Fix for building errors in exemplary plugins, changed order of arguments for g++

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -8,10 +8,10 @@ clean:
 	rm -f snap-publisher-log
 
 snap-collector-rando:
-	c++ --std=c++11 -lsnap -lprotobuf -lgrpc++ -o snap-collector-rando rando/src/rando.cc
+	c++ --std=c++11 -o snap-collector-rando rando/src/rando.cc -lsnap -lprotobuf -lgrpc++
 
 snap-processor-graf:
-	c++ --std=c++11 -lsnap -lprotobuf -lgrpc++ -o snap-processor-graf graffiti/src/graffiti.cc
+	c++ --std=c++11 -o snap-processor-graf graffiti/src/graffiti.cc -lsnap -lprotobuf -lgrpc++
 
 snap-publisher-log:
-	c++ --std=c++11 -lsnap -lprotobuf -lgrpc++ -o snap-publisher-log log/src/log.cc
+	c++ --std=c++11 -o snap-publisher-log log/src/log.cc -lsnap -lprotobuf -lgrpc++


### PR DESCRIPTION
Building errors appeared using g++ (Ubuntu 6.1.1-2ubuntu12~16.04) 6.1.1 20160510. 
Output of make (only several lines):
```
rm -f snap-collector-rando
rm -f snap-processor-graf
rm -f snap-publisher-log
c++ --std=c++11 -lsnap -lprotobuf -lgrpc++ -o snap-collector-rando rando/src/rando.cc
/tmp/cc1ELwoo.o: In function `Rando::get_config_policy()':
rando.cc:(.text+0x3c): undefined reference to `Plugin::ConfigPolicy::ConfigPolicy()'
rando.cc:(.text+0x193): undefined reference to `Plugin::ConfigPolicy::add_rule(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, Plugin::Rule<rpc::StringPolicy, rpc::StringRule, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const&)'
rando.cc:(.text+0x43b): undefined reference to `Plugin::ConfigPolicy::add_rule(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, Plugin::Rule<rpc::StringPolicy, rpc::StringRule, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const&)'
rando.cc:(.text+0x767): undefined reference to `Plugin::ConfigPolicy::~ConfigPolicy()'
/tmp/cc1ELwoo.o: In function `Rando::get_metric_types(Plugin::Config)':
rando.cc:(.text+0xb8e): undefined reference to `Plugin::Metric::Metric(std::vector<Plugin::Metric::NamespaceElement, std::allocator<Plugin::Metric::NamespaceElement> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
rando.cc:(.text+0xf4d): undefined reference to `Plugin::Metric::Metric(std::vector<Plugin::Metric::NamespaceElement, std::allocator<Plugin::Metric::NamespaceElement> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
rando.cc:(.text+0xfcc): undefined reference to `Plugin::Metric::~Metric()'
rando.cc:(.text+0x12ef): undefined reference to `Plugin::Metric::~Metric()'
/tmp/cc1ELwoo.o: In function `Rando::collect_metrics(std::vector<Plugin::Metric, std::allocator<Plugin::Metric> >*)':
rando.cc:(.text+0x1755): undefined reference to `Plugin::Metric::set_data(int)'
rando.cc:(.text+0x1769): undefined reference to `Plugin::Metric::set_timestamp()'
/tmp/cc1ELwoo.o: In function `main':
rando.cc:(.text+0x17f7): undefined reference to `Plugin::Meta::Meta(Plugin::Type, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int)'
rando.cc:(.text+0x1842): undefined reference to `Plugin::start_collector(Plugin::CollectorInterface*, Plugin::Meta const&)'
/tmp/cc1ELwoo.o: In function `google::protobuf::internal::GetEmptyStringAlreadyInited[abi:cxx11]()':
rando.cc:(.text._ZN6google8protobuf8internal27GetEmptyStringAlreadyInitedB5cxx11Ev[_ZN6google8protobuf8internal27GetEmptyStringAlreadyInitedB5cxx11Ev]+0x7): undefined reference to `google::protobuf::internal::empty_string_[abi:cxx11]'
rando.cc:(.text._ZN6google8protobuf8internal27GetEmptyStringAlreadyInitedB5cxx11Ev[_ZN6google8protobuf8internal27GetEmptyStringAlreadyInitedB5cxx11Ev]+0x2c): undefined reference to `google::protobuf::internal::empty_string_[abi:cxx11]'
/tmp/cc1ELwoo.o: In function `rpc::StringRule::operator=(rpc::StringRule const&)':
rando.cc:(.text._ZN3rpc10StringRuleaSERKS0_[_ZN3rpc10StringRuleaSERKS0_]+0x1f): undefined reference to `rpc::StringRule::CopyFrom(rpc::StringRule const&)'
/tmp/cc1ELwoo.o: In function `google::protobuf::internal::MapField<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, rpc::StringRule, (google::protobuf::internal::WireFormatLite::FieldType)9, (google::protobuf::internal::WireFormatLite::FieldType)11, 0>::MutableMap()':
rando.cc:(.text._ZN6google8protobuf8internal8MapFieldINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEN3rpc10StringRuleELNS1_14WireFormatLite9FieldTypeE9ELSC_11ELi0EE10MutableMapEv[_ZN6google8protobuf8internal8MapFieldINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEN3rpc10StringRuleELNS1_14WireFormatLite9FieldTypeE9ELSC_11ELi0EE10MutableMapEv]+0x14): undefined reference to `google::protobuf::internal::MapFieldBase::SyncMapWithRepeatedField() const'
rando.cc:(.text._ZN6google8protobuf8internal8MapFieldINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEN3rpc10StringRuleELNS1_14WireFormatLite9FieldTypeE9ELSC_11ELi0EE10MutableMapEv[_ZN6google8protobuf8internal8MapFieldINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEN3rpc10StringRuleELNS1_14WireFormatLite9FieldTypeE9ELSC_11ELi0EE10MutableMapEv]+0x34): undefined reference to `google::protobuf::internal::MapFieldBase::SetMapDirty()'
```