### PR TITLE
(SDI-2025) Fixes #14 and #15. Proper namespace setting and const correctness

### DIFF
--- a/examples/graffiti/src/graffiti.cc
+++ b/examples/graffiti/src/graffiti.cc
@@ -38,14 +38,14 @@ const ConfigPolicy Graffiti::get_config_policy() {
   return policy;
 }
 
-void Graffiti::process_metrics(std::vector<Metric>* metrics,
+void Graffiti::process_metrics(std::vector<Metric> &metrics,
                                const Config& config) {
   std::vector<Metric>::iterator mets_iter;
   std::string tags_str = config.get_string("tags");
 
   std::vector<std::string> tags = split_tags(tags_str);
 
-  for (mets_iter = metrics->begin(); mets_iter != metrics->end(); mets_iter++) {
+  for (mets_iter = metrics.begin(); mets_iter != metrics.end(); mets_iter++) {
     for (std::string tag : tags) {
       mets_iter->add_tag(std::pair<std::string, std::string>(tag, "present"));
     }

--- a/examples/graffiti/src/graffiti.h
+++ b/examples/graffiti/src/graffiti.h
@@ -22,6 +22,6 @@ limitations under the License.
 class Graffiti final : public Plugin::ProcessorInterface {
  public:
   const Plugin::ConfigPolicy get_config_policy();
-  void process_metrics(std::vector<Plugin::Metric>* metrics,
+  void process_metrics(std::vector<Plugin::Metric> &metrics,
                        const Plugin::Config& config);
 };

--- a/examples/log/src/log.cc
+++ b/examples/log/src/log.cc
@@ -45,7 +45,7 @@ const ConfigPolicy Log::get_config_policy() {
 /**
  * {ISO 8601 timestamp} {namespace} tags: [{tags}] data: {data}
  */
-void Log::publish_metrics(std::vector<Metric>* metrics,
+void Log::publish_metrics(std::vector<Metric> &metrics,
                           const Config& config) {
   std::string path = config.get_string("path");
   std::ofstream outfile;
@@ -53,7 +53,7 @@ void Log::publish_metrics(std::vector<Metric>* metrics,
 
   std::vector<Metric>::iterator mets_iter;
 
-  for (mets_iter = metrics->begin(); mets_iter != metrics->end(); mets_iter++) {
+  for (mets_iter = metrics.begin(); mets_iter != metrics.end(); mets_iter++) {
     // timestamp
     system_clock::time_point ts = mets_iter->timestamp();
     std::time_t c_ts = system_clock::to_time_t(ts);

--- a/examples/log/src/log.h
+++ b/examples/log/src/log.h
@@ -22,6 +22,6 @@ limitations under the License.
 class Log final : public Plugin::PublisherInterface {
  public:
   const Plugin::ConfigPolicy get_config_policy();
-  void publish_metrics(std::vector<Plugin::Metric>* metrics,
+  void publish_metrics(std::vector<Plugin::Metric> &metrics,
                        const Plugin::Config& config);
 };

--- a/examples/rando/src/rando.cc
+++ b/examples/rando/src/rando.cc
@@ -75,10 +75,10 @@ std::vector<Metric> Rando::get_metric_types(Config cfg) {
   return metrics;
 }
 
-void Rando::collect_metrics(std::vector<Metric>* metrics) {
+void Rando::collect_metrics(std::vector<Metric> &metrics) {
   std::vector<Metric>::iterator mets_iter;
   unsigned int seed = time(NULL);
-  for (mets_iter = metrics->begin(); mets_iter != metrics->end(); mets_iter++) {
+  for (mets_iter = metrics.begin(); mets_iter != metrics.end(); mets_iter++) {
     mets_iter->set_data(rand_r(&seed) % 1000);
     mets_iter->set_timestamp();
   }

--- a/examples/rando/src/rando.h
+++ b/examples/rando/src/rando.h
@@ -23,5 +23,5 @@ class Rando final : public Plugin::CollectorInterface {
  public:
   const Plugin::ConfigPolicy get_config_policy();
   std::vector<Plugin::Metric> get_metric_types(Plugin::Config cfg);
-  void collect_metrics(std::vector<Plugin::Metric>* metrics);
+  void collect_metrics(std::vector<Plugin::Metric> &metrics);
 };

--- a/src/snap/metric.cc
+++ b/src/snap/metric.cc
@@ -105,12 +105,13 @@ const std::vector<Metric::NamespaceElement>& Metric::ns() const {
 
 std::vector<int> Metric::dynamic_ns_elements() const {
   std::vector<int> idxs;
-  RepeatedPtrField<rpc::NamespaceElement> rpc_ns = rpc_metric_ptr->namespace_();
-  
-  for (int i = 0; i < rpc_ns.size(); i++) {
-    if (rpc_ns.Get(i).name().empty()) {
+  const std::vector<Metric::NamespaceElement>& namesp = ns();
+  int i = 0; 
+  for (auto element : namesp) {
+    if (!element.name.empty()) {
       idxs.push_back(i);    
     }
+    i++;
   }
   return idxs;
 }
@@ -122,7 +123,7 @@ void Metric::add_tag(std::pair<std::string, std::string> pair) {
   (*rpc_tags)[pair.first] = pair.second;
 }
 
-const std::map<std::string, std::string>& Metric::tags() {
+const std::map<std::string, std::string>& Metric::tags() const {
   if (memo_tags.size() != 0) {
     return memo_tags;
   }
@@ -136,7 +137,7 @@ const std::map<std::string, std::string>& Metric::tags() {
  * rpc::Time is a structure containing seconds and nanoseconds. To retrieve an
  * accurate timestamp, these two counters must be summed.
  */
-system_clock::time_point Metric::timestamp() {
+system_clock::time_point Metric::timestamp() const {
   // retrieve the tpc::Time
   rpc::Time rpc_tm = rpc_metric_ptr->timestamp();
 

--- a/src/snap/metric.cc
+++ b/src/snap/metric.cc
@@ -69,16 +69,23 @@ Metric::~Metric() {
 }
 
 void Metric::set_ns(std::vector<Metric::NamespaceElement> ns) {
-  std::vector<Metric::NamespaceElement> memo_ns;
+  memo_ns.clear();
+  rpc_metric_ptr->clear_namespace_();
+
   for (Metric::NamespaceElement ns_elem : ns) {
     rpc::NamespaceElement* rpc_elem = rpc_metric_ptr->add_namespace_();
     rpc_elem->set_name(ns_elem.name);
     rpc_elem->set_value(ns_elem.value);
     rpc_elem->set_description(ns_elem.description);
+    memo_ns.push_back({
+      rpc_elem->value(),
+      rpc_elem->name(),
+      rpc_elem->description(),
+    });
   }
 }
 
-const std::vector<Metric::NamespaceElement>& Metric::ns() {
+const std::vector<Metric::NamespaceElement>& Metric::ns() const {
   if (memo_ns.size() != 0) {
     return memo_ns;
   }
@@ -96,15 +103,14 @@ const std::vector<Metric::NamespaceElement>& Metric::ns() {
   return memo_ns;
 }
 
-std::vector<int> Metric::dynamic_ns_elements() {
-  const std::vector<Metric::NamespaceElement>& namesp = ns();
+std::vector<int> Metric::dynamic_ns_elements() const {
   std::vector<int> idxs;
-  int i = 0;
-  for (Metric::NamespaceElement nse : namesp) {
-    if (!nse.name.empty()) {
-      idxs.push_back(i);
+  RepeatedPtrField<rpc::NamespaceElement> rpc_ns = rpc_metric_ptr->namespace_();
+  
+  for (int i = 0; i < rpc_ns.size(); i++) {
+    if (rpc_ns.Get(i).name().empty()) {
+      idxs.push_back(i);    
     }
-    i++;
   }
   return idxs;
 }
@@ -188,20 +194,28 @@ void Metric::set_data(const std::string& data) {
   rpc_metric_ptr->set_string_data(data);
 }
 
-int Metric::get_int_data() {
+int Metric::get_int_data() const {
   return rpc_metric_ptr->int32_data();
 }
 
-float Metric::get_float32_data() {
+float Metric::get_float32_data() const {
   return rpc_metric_ptr->float32_data();
 }
 
-double Metric::get_float64_data() {
+double Metric::get_float64_data() const {
   return rpc_metric_ptr->float64_data();
 }
 
-const std::string& Metric::get_string_data() {
+const std::string& Metric::get_string_data() const {
   return rpc_metric_ptr->string_data();
+}
+
+Plugin::Config Metric::get_config() const {
+  return config;
+}
+
+const rpc::Metric* Metric::get_rpc_metric_ptr() const {
+  return rpc_metric_ptr;
 }
 
 void Metric::set_ts(system_clock::time_point tp) {

--- a/src/snap/metric.h
+++ b/src/snap/metric.h
@@ -113,7 +113,7 @@ class Metric final {
    * If there is a memoized copy, that is returned. Else the tags are copied
    * into the cache then returned.
    */
-  const std::map<std::string, std::string>& tags();
+  const std::map<std::string, std::string>& tags() const;
 
   /**
    * set_ns adds tags to the metric in its `rpc::Metric` ptr.
@@ -126,7 +126,7 @@ class Metric final {
   /**
    * timestamp returns the metric's collection timestamp.
    */
-  std::chrono::system_clock::time_point timestamp();
+  std::chrono::system_clock::time_point timestamp() const;
   /**
    * set_timestamp sets the timestamp as now.
    */
@@ -179,7 +179,7 @@ class Metric final {
 
   // memoized members
   mutable std::vector<NamespaceElement> memo_ns;
-  std::map<std::string, std::string> memo_tags;
+  mutable std::map<std::string, std::string> memo_tags;
 
   bool delete_metric_ptr;
   DataType type;

--- a/src/snap/metric.h
+++ b/src/snap/metric.h
@@ -92,13 +92,13 @@ class Metric final {
    * If there is a memoized copy, that is returned. Else the namespace is
    * copied into the cache then returned.
    */
-  const std::vector<NamespaceElement>& ns();
+  const std::vector<NamespaceElement>& ns() const;
 
   /**
    * dynamic_ns_elements returns the indices in the metric's namespace which
    * are dynamic.
    */
-  std::vector<int> dynamic_ns_elements();
+  std::vector<int> dynamic_ns_elements() const;
 
   /**
    * set_ns sets the namespace of the metric in its `rpc::Metric` ptr.
@@ -163,21 +163,22 @@ class Metric final {
   /**
    * Retrieve this metric's datapoint
    */
-  int get_int_data();
-  float get_float32_data();
-  double get_float64_data();
-  const std::string& get_string_data();
+  int get_int_data() const;
+  float get_float32_data() const;
+  double get_float64_data() const;
+  const std::string& get_string_data() const;
+  Config get_config() const;
+  const rpc::Metric* get_rpc_metric_ptr() const;
 
+ private:
   rpc::Metric* rpc_metric_ptr;
   Config config;
 
-
- private:
   void inline set_ts(std::chrono::system_clock::time_point tp);
   void inline set_last_advert_tm(std::chrono::system_clock::time_point tp);
 
   // memoized members
-  std::vector<NamespaceElement> memo_ns;
+  mutable std::vector<NamespaceElement> memo_ns;
   std::map<std::string, std::string> memo_tags;
 
   bool delete_metric_ptr;

--- a/src/snap/plugin.h
+++ b/src/snap/plugin.h
@@ -112,7 +112,7 @@ class CollectorInterface : public PluginInterface {
    * collect_metrics is given a list of metrics to collect.
    * It should collect and annotate each metric with the apropos context.
    */
-  virtual void collect_metrics(std::vector<Metric>* metrics) = 0;
+  virtual void collect_metrics(std::vector<Metric> &metrics) = 0;
 };
 
 /**
@@ -123,7 +123,7 @@ class CollectorInterface : public PluginInterface {
 class ProcessorInterface : public PluginInterface {
  public:
   virtual ~ProcessorInterface() {}
-  virtual void process_metrics(std::vector<Metric>* metrics,
+  virtual void process_metrics(std::vector<Metric> &metrics,
                                const Config& config) = 0;
 };
 
@@ -135,7 +135,7 @@ class ProcessorInterface : public PluginInterface {
 class PublisherInterface : public PluginInterface {
  public:
   virtual ~PublisherInterface() {}
-  virtual void publish_metrics(std::vector<Metric>* metrics,
+  virtual void publish_metrics(std::vector<Metric> &metrics,
                                const Config& config) = 0;
 };
 

--- a/src/snap/proxy/collector_proxy.cc
+++ b/src/snap/proxy/collector_proxy.cc
@@ -57,10 +57,10 @@ Status CollectorImpl::CollectMetrics(ServerContext* context,
     metrics.emplace_back(rpc_mets.Mutable(i));
   }
 
-  collector->collect_metrics(&metrics);
+  collector->collect_metrics(metrics);
 
   for (Metric met : metrics) {
-    *resp->add_metrics() = *met.rpc_metric_ptr;
+    *resp->add_metrics() = *met.get_rpc_metric_ptr();
   }
   return Status::OK;
 }
@@ -75,7 +75,7 @@ Status CollectorImpl::GetMetricTypes(ServerContext* context,
   for (Metric met : metrics) {
     met.set_timestamp();
     met.set_last_advertised_time();
-    *resp->add_metrics() = *met.rpc_metric_ptr;
+    *resp->add_metrics() = *met.get_rpc_metric_ptr();
   }
   return Status::OK;
 }

--- a/src/snap/proxy/processor_proxy.cc
+++ b/src/snap/proxy/processor_proxy.cc
@@ -54,10 +54,10 @@ Status ProcessorImpl::Process(ServerContext* context, const PubProcArg* req,
   }
 
   Plugin::Config config(req->config());
-  processor->process_metrics(&metrics, config);
+  processor->process_metrics(metrics, config);
 
   for (Metric met : metrics) {
-    *resp->add_metrics() = *met.rpc_metric_ptr;
+    *resp->add_metrics() = *met.get_rpc_metric_ptr();
   }
   return Status::OK;
 }

--- a/src/snap/proxy/publisher_proxy.cc
+++ b/src/snap/proxy/publisher_proxy.cc
@@ -53,7 +53,7 @@ Status PublisherImpl::Publish(ServerContext* context, const PubProcArg* req,
   }
 
   Plugin::Config config(req->config());
-  publisher->publish_metrics(&metrics, config);
+  publisher->publish_metrics(metrics, config);
 
   return Status::OK;
 }


### PR DESCRIPTION
Fixes #14 and #15 

- `Metric:set_ns()` is now properly set
- const correctness on getters
- changes interface for `collect_metrics`, `process_metrics` and `publish_metrics` to reference to vector

@intelsdi-x/snap-maintainers  @intelsdi-x/plugin-maintainers 