### PR TITLE
Renaming snapd to snapteld, fixed link to snap's maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ $ git checkout -b some-topic-branch
 * Open a pull request for the appropriate project.
 * Contributors will review your pull request, suggest changes, and merge it when it’s ready and/or offer feedback.
 
-If you have questions feel free to contact the [maintainers](https://github.com/intelsdi-x/snap/blob/master/README.md#maintainers).
+If you have questions feel free to contact the [maintainers](https://github.com/intelsdi-x/snap/blob/master/docs/MAINTAINERS.md).
 
 ## Contributing Examples
 The most immediately helpful way you can benefit this project is by cloning the repository, adding some further examples and submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2016 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 Snap Plugin Library for C++
 ===========================
 

--- a/src/snap/config.h
+++ b/src/snap/config.h
@@ -128,7 +128,7 @@ class ConfigPolicy final : public rpc::GetConfigPolicyReply {
 };
 
 /**
- * Config is the incoming configuration data which has been vetted by snapd
+ * Config is the incoming configuration data which has been vetted by snapteld
  * according to the plugin's ConfigPolicy.
  *
  */

--- a/src/snap/grpc_export.cc
+++ b/src/snap/grpc_export.cc
@@ -109,7 +109,7 @@ void Plugin::GRPCExportImpl::doAdvertise() {
                    // The gRPC client in Snap does not use the `Unsecure` metadata key at
                    // this time, as it is used for payload encryption.  With gRPC, encryption
                    // is done via its transport, and this will be updated once support for
-                   // that feature lands in snapd.
+                   // that feature lands in snapteld.
                    {"Unsecure", true},
                    {"CacheTTL", meta->cache_ttl.count()},
                    {"RoutingStrategy", meta->strategy}

--- a/src/snap/plugin.h
+++ b/src/snap/plugin.h
@@ -49,7 +49,7 @@ enum RpcType {
 
 /**
  * Strategy is the routing and caching strategy this plugin requires.
- * A routing and caching Strategy is the method which snapd uses to cache 
+ * A routing and caching Strategy is the method which snapteld uses to cache
  * metrics, and select the correct running instance of a plugin.
  */
 enum Strategy {


### PR DESCRIPTION
Summary of changes:
- fixed link to Snap' maintainers in `CONTRIBUTING.md`
- changed filename to capital letters (readme.md -> README.md) to keep consistency with others repos and added the license header 
- renamed `snapd` -> `snapteld` in all occurrences
