### PR TITLE
Fixed header to be inside markdown comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-/*
+<!--
 http://www.apache.org/licenses/LICENSE-2.0.txt
     Copyright 2016 Intel Corporation
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,7 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/
+-->
 
 Snap Plugin Library for C++
 ===========================


### PR DESCRIPTION
Summary of changes:
- put license header as a markdown comment

