### PR TITLE
Updated Makefiles for general plugin dev with static linking instead of dynamic

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -14,21 +14,80 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-.PHONY: build clean
 
-build: clean test-collector-rando test-processor-graffiti test-publisher-log
+# Collector build
+A_PREFIX=test
+A_TYPE=collector
+A_NAME=rando
+A_TARGET=$(A_PREFIX)-$(A_TYPE)-$(A_NAME)
+A_DIR=$(A_TYPE)/src
 
-clean:
-	rm -f test-collector-rando
-	rm -f test-processor-graffiti
-	rm -f test-publisher-log
+# Processor build
+B_PREFIX=test
+B_TYPE=processor
+B_NAME=graffiti
+B_TARGET=$(B_PREFIX)-$(B_TYPE)-$(B_NAME)
+B_DIR=$(B_TYPE)/src
 
-test-collector-rando:
-	c++ --std=c++0x ${CPP_FLAGS} -o test-collector-rando collector/src/rando.cc ${CPP_FLAGS_POST} -lsnap -lprotobuf -lgrpc++
+# Publisher build
+C_PREFIX=test
+C_TYPE=publisher
+C_NAME=log
+C_TARGET=$(C_PREFIX)-$(C_TYPE)-$(C_NAME)
+C_DIR=$(C_TYPE)/src
 
-test-processor-graffiti:
-	c++ --std=c++0x ${CPP_FLAGS} -o test-processor-graffiti processor/src/graffiti.cc ${CPP_FLAGS_POST} -lsnap -lprotobuf -lgrpc++
+A_PATH=$(PWD)
 
-test-publisher-log:
-	c++ --std=c++0x ${CPP_FLAGS} -o test-publisher-log publisher/src/log.cc ${CPP_FLAGS_POST} -lsnap -lprotobuf -lgrpc++
+all: $(A_TARGET) $(B_TARGET) $(C_TARGET)   # Build all targets
 
+.PHONY: all help clean rebuild install uninstall $(A_TARGET) $(A_TARGET)-clean $(A_TARGET)-install $(A_TARGET)-uninstall $(B_TARGET) $(B_TARGET)-clean $(B_TARGET)-install $(B_TARGET)-uninstall $(C_TARGET) $(C_TARGET)-clean $(C_TARGET)-install $(C_TARGET)-uninstall
+
+help:                                      # Show Makefile targets
+        @egrep "[a-z]\w+:" Makefile | sort
+
+clean: $(A_TARGET)-clean $(B_TARGET)-clean $(C_TARGET)-clean
+
+rebuild: clean all                      # Clean and build targets
+
+install: $(A_TARGET)-install $(B_TARGET)-install $(C_TARGET)-install
+
+uninstall: $(A_TARGET)-uninstall $(B_TARGET)-uninstall $(C_TARGET)-uninstall
+
+
+$(A_TARGET):
+	@(cd $(A_DIR); make; echo " ") 
+
+$(A_TARGET)-clean:
+	@(cd $(A_DIR); make clean; echo " ") 
+
+$(A_TARGET)-install:
+	@(cd $(A_DIR); make install; echo " ")
+
+$(A_TARGET)-uninstall:
+	@(cd $(A_DIR); make uninstall; echo " ")
+
+
+$(B_TARGET):
+	@(cd $(B_DIR); make; echo " ")
+
+$(B_TARGET)-clean:
+	@(cd $(B_DIR); make clean; echo " ") 
+
+$(B_TARGET)-install:
+	@(cd $(B_DIR); make install; echo " ")
+
+$(B_TARGET)-uninstall:
+	@(cd $(B_DIR); make uninstall; echo " ")
+
+
+$(C_TARGET):
+	@(cd $(C_DIR); make; echo " ") 
+
+$(C_TARGET)-clean:
+	@(cd $(C_DIR); make clean; echo " ")
+
+$(C_TARGET)-install:
+	@(cd $(C_DIR); make install; echo " ")
+
+$(C_TARGET)-uninstall:
+	@(cd $(C_DIR); make uninstall; echo " ")

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 -->
 
 ## Snap Plugin C++ Library Examples
-Here you will find example plugins that cover the basics for writing collector, processor and publisher plugins.
+Here you will find example plugins that cover the basics for writing collector, processor and publisher plugins. When compiling source code, use static linking. This will ensure dependent libraries are built into the binaries and not required to locate libs during runtime.
 
 ## Build Plugins & Use with Snap
 
@@ -32,11 +32,12 @@ To test these plugins with Snap, you will need to have [Snap](https://github.com
 Refer to [repository README](../README.md#building-libsnap) for installation instructions.
 
 ### 3. Build the collector, processor, and/or publisher plugins in the examples folder.
-Enter the examples directory and execute `make`:
+Enter the examples directory and execute `make`, followed by 'make install'. With 'make install', the example plugin libraries will be copied into examples/bin:
 
 ```sh
 $ cd examples
 $ make
+$ make install
 ```
 
 ### 4. Launch example task in `examples` directory:

--- a/examples/bin/README.md
+++ b/examples/bin/README.md
@@ -1,0 +1,21 @@
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2017 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## Snap Plugin Library for C++:
+This bin directory is used as a common location to save Snap Plugin binaries. The examples will automatically copy compiled binaries here following the execution of 'make install' 

--- a/examples/collector/src/Makefile
+++ b/examples/collector/src/Makefile
@@ -1,0 +1,69 @@
+# http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+PLUGINTYPE=collector
+NAME=rando
+TARGET=test-$(PLUGINTYPE)-$(NAME)
+
+SNAPLIBS=/usr/local/lib
+ICCROOT=
+EROOT=../..
+BDIR=$(EROOT)/bin
+
+CC=g++
+IDIRS=-I.
+LDIRS=-L.
+CFLAGS=-std=c++1y
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lz -lpthread
+FILES := $(wildcard *.cc)
+
+all: $(TARGET)				# Build all targets
+
+vars:					# Show Makefile variable values
+	@echo "  PLUGINTYPE "$(PLUGINTYPE)
+	@echo "        NAME "$(NAME)
+	@echo "      TARGET "$(TARGET)
+	@echo "" 
+	@echo "    SNAPLIBS "$(SNAPLIBS) 
+	@echo "     ICCROOT "$(ICCROOT) 
+	@echo "       EROOT "$(EROOT)
+	@echo "        BDIR "$(BDIR)
+	@echo "" 
+	@echo "          CC "$(CC)
+	@echo "       IDIRS "$(IDIRS)
+	@echo "       LDIRS "$(LDIRS)
+	@echo "      CFLAGS "$(FLAGS)
+	@echo "        LIBS "$(LIBS)
+	@echo "       FILES "$(FILES)
+
+help:					# Show Makefile targets
+	@egrep "[a-z]\w+:" Makefile | sort
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY:	all clean vars help install uninstall rebuild $(TARGET)
+
+install:
+	cp $(TARGET) $(BDIR)
+
+uninstall:
+	rm -f $(BDIR)/$(TARGET)
+
+rebuild: clean $(TARGET)		# Clean and build target
+
+$(TARGET):
+	$(CC) $(CFLAGS) $(IDIRS) $(LDIRS) -o $(TARGET) $(FILES) $(LIBS)

--- a/examples/processor/src/Makefile
+++ b/examples/processor/src/Makefile
@@ -1,0 +1,69 @@
+# http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+PLUGINTYPE=processor
+NAME=graffiti
+TARGET=test-$(PLUGINTYPE)-$(NAME)
+
+SNAPLIBS=/usr/local/lib
+ICCROOT=
+EROOT=../..
+BDIR=$(EROOT)/bin
+
+CC=g++
+IDIRS=-I.
+LDIRS=-L.
+CFLAGS=-std=c++1y
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lz -lpthread
+FILES := $(wildcard *.cc)
+
+all: $(TARGET)				# Build all targets
+
+vars:					# Show Makefile variable values
+	@echo "  PLUGINTYPE "$(PLUGINTYPE)
+	@echo "        NAME "$(NAME)
+	@echo "      TARGET "$(TARGET)
+	@echo "" 
+	@echo "    SNAPLIBS "$(SNAPLIBS) 
+	@echo "     ICCROOT "$(ICCROOT) 
+	@echo "       EROOT "$(EROOT)
+	@echo "        BDIR "$(BDIR)
+	@echo "" 
+	@echo "          CC "$(CC)
+	@echo "       IDIRS "$(IDIRS)
+	@echo "       LDIRS "$(LDIRS)
+	@echo "      CFLAGS "$(FLAGS)
+	@echo "        LIBS "$(LIBS)
+	@echo "       FILES "$(FILES)
+
+help:					# Show Makefile targets
+	@egrep "[a-z]\w+:" Makefile | sort
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY:	all clean vars help install uninstall rebuild $(TARGET)
+
+install:
+	cp $(TARGET) $(BDIR)
+
+uninstall:
+	rm -f $(BDIR)/$(TARGET)
+
+rebuild: clean $(TARGET)		# Clean and build target
+
+$(TARGET):
+	$(CC) $(CFLAGS) $(IDIRS) $(LDIRS) -o $(TARGET) $(FILES) $(LIBS)

--- a/examples/publisher/src/Makefile
+++ b/examples/publisher/src/Makefile
@@ -1,0 +1,69 @@
+# http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+PLUGINTYPE=publisher
+NAME=log
+TARGET=test-$(PLUGINTYPE)-$(NAME)
+
+SNAPLIBS=/usr/local/lib
+ICCROOT=
+EROOT=../..
+BDIR=$(EROOT)/bin
+
+CC=g++
+IDIRS=-I.
+LDIRS=-L.
+CFLAGS=-std=c++1y
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lz -lpthread
+FILES := $(wildcard *.cc)
+
+all: $(TARGET)				# Build all targets
+
+vars:					# Show Makefile variable values
+	@echo "  PLUGINTYPE "$(PLUGINTYPE)
+	@echo "        NAME "$(NAME)
+	@echo "      TARGET "$(TARGET)
+	@echo "" 
+	@echo "    SNAPLIBS "$(SNAPLIBS) 
+	@echo "     ICCROOT "$(ICCROOT) 
+	@echo "       EROOT "$(EROOT)
+	@echo "        BDIR "$(BDIR)
+	@echo "" 
+	@echo "          CC "$(CC)
+	@echo "       IDIRS "$(IDIRS)
+	@echo "       LDIRS "$(LDIRS)
+	@echo "      CFLAGS "$(FLAGS)
+	@echo "        LIBS "$(LIBS)
+	@echo "       FILES "$(FILES)
+
+help:					# Show Makefile targets
+	@egrep "[a-z]\w+:" Makefile | sort
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY:	all clean vars help install uninstall rebuild $(TARGET)
+
+install:
+	cp $(TARGET) $(BDIR)
+
+uninstall:
+	rm -f $(BDIR)/$(TARGET)
+
+rebuild: clean $(TARGET)		# Clean and build target
+
+$(TARGET):
+	$(CC) $(CFLAGS) $(IDIRS) $(LDIRS) -o $(TARGET) $(FILES) $(LIBS)

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-snaptel plugin load test-collector-rando
-snaptel plugin load test-processor-graffiti
-snaptel plugin load test-publisher-log
+snaptel plugin load bin/test-collector-rando
+snaptel plugin load bin/test-processor-graffiti
+snaptel plugin load bin/test-publisher-log
 snaptel task create -t task.json
 


### PR DESCRIPTION
Due to Snap v1 losing user defined env vars during runtime with dynamic liinks, changed make to use static lib build.

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #

Summary of changes:
- Creation of generalized Makefile for example plugins
- Changed libs to use static linking due to dynamic libs not all found during runtime with Snap v1.0. (E.g., user defined environment not preserved during runtime)
- Updated example README files

How to verify it:
- run 'make', 'make install' in examples dir, then './run.sh' when Snap is running.

Testing done:
- Verified compile, load, and runtime operation of plugins

A picture of a snapping turtle (not required but encouraged):
-         ^^^
   - =====  BD<
         V    V
