### PR TITLE
Added support for standalone plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Dependencies:
 * grpc++ (see below)
 * libtool
 * make
+* [spdlog v0.13.0](https://github.com/gabime/spdlog/releases)
+* [boost c++ libs v1.58.0](http://www.boost.org)
+* [cpp-netlib v0.11.2](http://cpp-netlib.org)
 
 ### Building GRPC from source
 

--- a/examples/collector/src/Makefile
+++ b/examples/collector/src/Makefile
@@ -27,7 +27,7 @@ CC=g++
 IDIRS=-I.
 LDIRS=-L.
 CFLAGS=-std=c++1y
-LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lz -lpthread
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers -lz -lpthread -lssl -lcrypto
 FILES := $(wildcard *.cc)
 
 all: $(TARGET)				# Build all targets

--- a/examples/collector/src/rando.cc
+++ b/examples/collector/src/rando.cc
@@ -17,16 +17,22 @@ limitations under the License.
 #include <string>
 #include <time.h>
 #include <vector>
+#include <iostream>
 
 #include <snap/config.h>
 #include <snap/plugin.h>
 #include <snap/metric.h>
+#include <snap/flags.h>
 
 using Plugin::Config;
 using Plugin::ConfigPolicy;
 using Plugin::Metric;
 using Plugin::Meta;
 using Plugin::Type;
+using Plugin::Flags;
+
+using std::cout;
+using std::endl;
 
 enum supported_types
 {
@@ -41,172 +47,173 @@ enum supported_types
 };
 
 std::map<std::string, int> metric_types{
-   {"float32", float32},
-   {"float64", float64},
-   {"int32", int32},
-   {"int64", int64},
-   {"uint32", uint32},
-   {"uint64", uint64},
-   {"boolean", boolean},
-   {"string", string},
+    {"float32", supported_types::float32},
+    {"float64", supported_types::float64},
+    {"int32", supported_types::int32},
+    {"int64", supported_types::int64},
+    {"uint32", supported_types::uint32},
+    {"uint64", supported_types::uint64},
+    {"boolean", supported_types::boolean},
+    {"string", supported_types::string}
 };
 
 const ConfigPolicy Rando::get_config_policy() {
-  ConfigPolicy policy;
-  policy.add_rule({"intel", "cpp"},
-  Plugin::StringRule{
-    "username",
-    {
-      "root",
-      false
-    }
-  });
-  policy.add_rule({"intel", "cpp", "mock", "randomnumber", "float32"},
-  Plugin::StringRule{
-    "password",
-    {
-      "h4ck3r",
-      true
-    }
-  });
-  return policy;
+    ConfigPolicy policy;
+    policy.add_rule({"intel", "cpp"},
+    Plugin::StringRule{
+        "username",
+        {"root", false}
+    });
+    policy.add_rule({"intel", "cpp", "mock", "randomnumber", "float32"},
+    Plugin::StringRule{
+        "password",
+        {"h4ck3r", true}
+    });
+    return policy;
 }
 
 std::vector<Metric> Rando::get_metric_types(Config cfg) {
-  std::vector<Metric> metrics = {
-    {
-      {
-        {"intel", "", ""},
-        {"cpp", "", ""},
-        {"mock", "", ""},
-        {"randomnumber", "", ""},
-        {"float32", "", ""},
-      },
-      "",
-      "float32 random number"
-    },
-    {
-      {
-        {"intel", "", ""},
-        {"cpp", "", ""},
-        {"mock", "", ""},
-        {"randomnumber", "", ""},
-        {"float64", "", ""},
-      },
-      "",
-      "float64 random number"
-    },
-    {
-      {
-        {"intel", "", ""},
-        {"cpp", "", ""},
-        {"mock", "", ""},
-        {"randomnumber", "", ""},
-        {"int32", "", ""},
-      },
-      "",
-      "int32 random number"
-    },
-    {
-      {
-        {"intel", "", ""},
-        {"cpp", "", ""},
-        {"mock", "", ""},
-        {"randomnumber", "", ""},
-        {"int64", "", ""},
-      },
-      "",
-      "int64 random number"
-    },
-    {
-      {
-        {"intel", "", ""},
-        {"cpp", "", ""},
-        {"mock", "", ""},
-        {"randomnumber", "", ""},
-        {"uint32", "", ""},
-      },
-      "",
-      "uint32 random number"
-    },
-    {
-      {
-        {"intel", "", ""},
-        {"cpp", "", ""},
-        {"mock", "", ""},
-        {"randomnumber", "", ""},
-        {"uint64", "", ""},
-      },
-      "",
-      "uint64 random number"
-    },
-    {
-      {
-        {"intel", "", ""},
-        {"cpp", "", ""},
-        {"mock", "", ""},
-        {"randomboolean", "", ""},
-        {"boolean", "", ""},
-      },
-      "",
-      "random boolean"
-    },
-    {
-      {
-        {"intel", "", ""},
-        {"cpp", "", ""},
-        {"mock", "", ""},
-        {"randomstring", "", ""},
-        {"string", "", ""},
-      },
-      "",
-      "random string"
-    }
-  };
-  return metrics;
+    std::vector<Metric> metrics = {
+        {
+            {
+                {"intel", "", ""},
+                {"cpp", "", ""},
+                {"mock", "", ""},
+                {"randomnumber", "", ""},
+                {"float32", "", ""},
+            },
+            "",
+            "float32 random number"
+        },
+        {
+            {
+                {"intel", "", ""},
+                {"cpp", "", ""},
+                {"mock", "", ""},
+                {"randomnumber", "", ""},
+                {"float64", "", ""},
+            },
+            "",
+            "float64 random number"
+        },
+        {
+            {
+                {"intel", "", ""},
+                {"cpp", "", ""},
+                {"mock", "", ""},
+                {"randomnumber", "", ""},
+                {"int32", "", ""},
+            },
+            "",
+            "int32 random number"
+            },
+        {
+            {
+                {"intel", "", ""},
+                {"cpp", "", ""},
+                {"mock", "", ""},
+                {"randomnumber", "", ""},
+                {"int64", "", ""},
+            },
+            "",
+            "int64 random number"
+        },
+        {
+            {
+                {"intel", "", ""},
+                {"cpp", "", ""},
+                {"mock", "", ""},
+                {"randomnumber", "", ""},
+                {"uint32", "", ""},
+            },
+            "",
+            "uint32 random number"
+        },
+        {
+            {
+                {"intel", "", ""},
+                {"cpp", "", ""},
+                {"mock", "", ""},
+                {"randomnumber", "", ""},
+                {"uint64", "", ""},
+            },
+            "",
+            "uint64 random number"
+        },
+        {
+            {
+                {"intel", "", ""},
+                {"cpp", "", ""},
+                {"mock", "", ""},
+                {"randomboolean", "", ""},
+                {"boolean", "", ""},
+            },
+            "",
+            "random boolean"
+        },
+        {
+            {
+                {"intel", "", ""},
+                {"cpp", "", ""},
+                {"mock", "", ""},
+                {"randomstring", "", ""},
+                {"string", "", ""},
+            },
+            "",
+            "random string"
+        }
+    };
+    return metrics;
 }
 
 void Rando::collect_metrics(std::vector<Metric> &metrics) {
-  std::vector<Metric>::iterator mets_iter;
-  unsigned int seed = time(NULL);
-  int random_value = rand_r(&seed) % 1000;
+    std::vector<Metric>::iterator mets_iter;
+    unsigned int seed = time(NULL);
+    int random_value = rand_r(&seed) % 1000;
 
-  for (mets_iter = metrics.begin(); mets_iter != metrics.end(); mets_iter++) {
-    std::string ns_mts_type = mets_iter->ns()[4].value;
-    int mts_type = metric_types[ns_mts_type];
+    for (mets_iter = metrics.begin(); mets_iter != metrics.end(); mets_iter++) {
+        std::string ns_mts_type = mets_iter->ns()[4].value;
+        int mts_type = metric_types[ns_mts_type];
 
-    switch(mts_type) {
-    case supported_types::float32:
-        mets_iter->set_data((float)random_value);
-        break;
-    case supported_types::float64:
-        mets_iter->set_data((double)random_value);
-        break;
-    case supported_types::int32:
-        mets_iter->set_data((int32_t)random_value);
-        break;
-    case supported_types::int64:
-        mets_iter->set_data((int64_t)random_value);
-        break;
-    case supported_types::uint32:
-        mets_iter->set_data((uint32_t)random_value);
-        break;
-    case supported_types::uint64:
-        mets_iter->set_data((uint64_t)random_value);
-        break;
-    case supported_types::boolean:
-        mets_iter->set_data(random_value%2 ? true : false);
-        break;
-    case supported_types::string:
-        mets_iter->set_data(std::to_string(random_value));
-        break;
+        switch(mts_type) {
+        case supported_types::float32:
+            mets_iter->set_data((float)random_value);
+            break;
+        case supported_types::float64:
+            mets_iter->set_data((double)random_value);
+            break;
+        case supported_types::int32:
+            mets_iter->set_data((int32_t)random_value);
+            break;
+        case supported_types::int64:
+            mets_iter->set_data((int64_t)random_value);
+            break;
+        case supported_types::uint32:
+            mets_iter->set_data((uint32_t)random_value);
+            break;
+        case supported_types::uint64:
+            mets_iter->set_data((uint64_t)random_value);
+            break;
+        case supported_types::boolean:
+            mets_iter->set_data(random_value%2 ? true : false);
+            break;
+        case supported_types::string:
+            mets_iter->set_data(std::to_string(random_value));
+            break;
+        }
+        mets_iter->set_timestamp();
     }
-    mets_iter->set_timestamp();
-  }
 }
 
-int main() {
-  Meta meta(Type::Collector, "rando", 1);
-  Rando plg = Rando();
-  start_collector(&plg, meta);
+int main(int argc, char **argv) {
+    Flags cli(argc, argv);
+    Meta meta(Type::Collector, "rando", 1, &cli);
+
+    if (cli.IsParsedFlag("version")) {
+        cout << meta.name << " version "  << meta.version << endl;
+        exit(0);
+    }
+
+    Rando plg;
+    start_collector(&plg, meta);
 }

--- a/examples/collector/src/rando.h
+++ b/examples/collector/src/rando.h
@@ -14,14 +14,16 @@ limitations under the License.
 #pragma once
 
 #include <vector>
+#include <iostream>
 
 #include <snap/config.h>
 #include <snap/metric.h>
 #include <snap/plugin.h>
+#include <snap/flags.h>
 
-class Rando final : public Plugin::CollectorInterface {
- public:
-  const Plugin::ConfigPolicy get_config_policy();
-  std::vector<Plugin::Metric> get_metric_types(Plugin::Config cfg);
-  void collect_metrics(std::vector<Plugin::Metric> &metrics);
+class Rando final : public Plugin::CollectorInterface {   
+    public:
+    const Plugin::ConfigPolicy get_config_policy();
+    std::vector<Plugin::Metric> get_metric_types(Plugin::Config cfg);
+    void collect_metrics(std::vector<Plugin::Metric> &metrics);
 };

--- a/examples/processor/src/Makefile
+++ b/examples/processor/src/Makefile
@@ -27,7 +27,7 @@ CC=g++
 IDIRS=-I.
 LDIRS=-L.
 CFLAGS=-std=c++1y
-LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lz -lpthread
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers -lz -lpthread -lssl -lcrypto
 FILES := $(wildcard *.cc)
 
 all: $(TARGET)				# Build all targets

--- a/examples/processor/src/graffiti.cc
+++ b/examples/processor/src/graffiti.cc
@@ -21,50 +21,57 @@ limitations under the License.
 #include <snap/config.h>
 #include <snap/plugin.h>
 #include <snap/metric.h>
+#include <snap/flags.h>
 
 using Plugin::Config;
 using Plugin::ConfigPolicy;
 using Plugin::Metric;
 using Plugin::Meta;
 using Plugin::Type;
+using Plugin::Flags;
 
 static inline std::vector<std::string> split_tags(std::string);
 
 const ConfigPolicy Graffiti::get_config_policy() {
-  ConfigPolicy policy(Plugin::StringRule{
-    "tags",
-    true
-  });
-  return policy;
+    ConfigPolicy policy(Plugin::StringRule{
+        "tags",
+        true
+    });
+    return policy;
 }
 
 void Graffiti::process_metrics(std::vector<Metric> &metrics,
                                const Config& config) {
-  std::vector<Metric>::iterator mets_iter;
-  std::string tags_str = config.get_string("tags");
+    std::vector<Metric>::iterator mets_iter;
+    std::string tags_str = config.get_string("tags");
 
-  std::vector<std::string> tags = split_tags(tags_str);
+    std::vector<std::string> tags = split_tags(tags_str);
 
-  for (mets_iter = metrics.begin(); mets_iter != metrics.end(); mets_iter++) {
-    for (std::string tag : tags) {
-      mets_iter->add_tag(std::pair<std::string, std::string>(tag, "present"));
+    for (mets_iter = metrics.begin(); mets_iter != metrics.end(); mets_iter++) {
+        for (std::string tag : tags) {
+        mets_iter->add_tag(std::pair<std::string, std::string>(tag, "present"));
+        }
     }
-  }
 }
 
-int main() {
-  Meta meta(Type::Processor, "graffiti", 1);
-  Graffiti plg = Graffiti();
-  start_processor(&plg, meta);
+int main(int argc, char **argv) {
+    Flags cli(argc, argv);
+    Meta meta(Type::Processor, "graffiti", 1, &cli);
+    if (cli.IsParsedFlag("version")) {
+        cout << meta.name << " version "  << meta.version << endl;
+        exit(0);
+    }
+    Graffiti plg = Graffiti();
+    start_processor(&plg, meta);
 }
 
 
 static inline std::vector<std::string> split_tags(std::string tags_str) {
-  std::stringstream tag_stream(tags_str);
-  std::string elem;
-  std::vector<std::string> tags;
-  while (getline(tag_stream, elem, ',')) {
-    if (!elem.empty()) tags.push_back(elem);
-  }
-  return tags;
+    std::stringstream tag_stream(tags_str);
+    std::string elem;
+    std::vector<std::string> tags;
+    while (getline(tag_stream, elem, ',')) {
+        if (!elem.empty()) tags.push_back(elem);
+    }
+    return tags;
 }

--- a/examples/processor/src/graffiti.h
+++ b/examples/processor/src/graffiti.h
@@ -20,8 +20,8 @@ limitations under the License.
 #include <snap/plugin.h>
 
 class Graffiti final : public Plugin::ProcessorInterface {
- public:
-  const Plugin::ConfigPolicy get_config_policy();
-  void process_metrics(std::vector<Plugin::Metric> &metrics,
-                       const Plugin::Config& config);
+public:
+    const Plugin::ConfigPolicy get_config_policy();
+    void process_metrics(std::vector<Plugin::Metric> &metrics,
+                        const Plugin::Config& config);
 };

--- a/examples/publisher/src/Makefile
+++ b/examples/publisher/src/Makefile
@@ -27,7 +27,7 @@ CC=g++
 IDIRS=-I.
 LDIRS=-L.
 CFLAGS=-std=c++1y
-LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lz -lpthread
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers -lz -lpthread -lssl -lcrypto
 FILES := $(wildcard *.cc)
 
 all: $(TARGET)				# Build all targets

--- a/examples/publisher/src/log.h
+++ b/examples/publisher/src/log.h
@@ -20,8 +20,8 @@ limitations under the License.
 #include <snap/plugin.h>
 
 class Log final : public Plugin::PublisherInterface {
- public:
-  const Plugin::ConfigPolicy get_config_policy();
-  void publish_metrics(std::vector<Plugin::Metric> &metrics,
-                       const Plugin::Config& config);
+public:
+    const Plugin::ConfigPolicy get_config_policy();
+    void publish_metrics(std::vector<Plugin::Metric> &metrics,
+                        const Plugin::Config& config);
 };

--- a/scripts/Dockerfile.travis
+++ b/scripts/Dockerfile.travis
@@ -18,7 +18,9 @@ FROM ubuntu:yakkety
 
 ## install deps
 RUN apt-get update -yq
-RUN apt-get install g++-4.9 gcc-4.9 protobuf-compiler libprotobuf-dev libprotoc-dev git curl cmake golang-go autoconf libtool ca-certificates -yq 
+RUN apt-get install g++-4.9 gcc-4.9 protobuf-compiler libprotobuf-dev libprotoc-dev \
+    libboost-dev libcppnetlib-dev libspdlog-dev \
+    git curl cmake golang-go autoconf libtool ca-certificates -yq 
 
 ## installing grpc
 RUN git clone -b v1.1.x --depth 1 -c advice.detachedHead=false  https://github.com/grpc/grpc /opt/grpc

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,6 +23,7 @@ nobase_include_HEADERS =         \
     snap/grpc_export_impl.h      \
     snap/plugin.h                \
     snap/lib_setup_impl.h        \
+    snap/flags.h                 \
     snap/proxy/plugin_proxy.h    \
     snap/proxy/collector_proxy.h \
     snap/proxy/processor_proxy.h \
@@ -35,6 +36,7 @@ libsnap_la_SOURCES =              \
     snap/config.cc                \
     snap/grpc_export.cc           \
     snap/plugin.cc                \
+    snap/flags.cc                 \
     snap/proxy/plugin_proxy.cc    \
     snap/proxy/collector_proxy.cc \
     snap/proxy/processor_proxy.cc \
@@ -42,6 +44,7 @@ libsnap_la_SOURCES =              \
     snap/rpc/plugin.pb.cc         \
     snap/rpc/plugin.grpc.pb.cc
 
-libsnap_la_CPPFLAGS = \
-    --std=c++0x       \
-    -I$(top_srcdir)/include
+libsnap_la_CPPFLAGS =       \
+    --std=c++1y             \
+    -I$(top_srcdir)/include 
+

--- a/src/snap/config.cc
+++ b/src/snap/config.cc
@@ -27,34 +27,34 @@ ConfigPolicy::ConfigPolicy() {}
 ConfigPolicy::~ConfigPolicy() {}
 
 ConfigPolicy::ConfigPolicy(const StringRule& rule) {
-  add_rule({""}, rule);
+    add_rule({""}, rule);
 }
 ConfigPolicy::ConfigPolicy(const IntRule& rule) {
-  add_rule({""}, rule);
+    add_rule({""}, rule);
 }
 ConfigPolicy::ConfigPolicy(const BoolRule& rule) {
-  add_rule({""}, rule);
+    add_rule({""}, rule);
 }
 
 void ConfigPolicy::add_rule(const std::vector<std::string>& ns,
                             const StringRule& rule) {
-  std::string key = build_key(ns);
-  auto policy_ptr = mutable_string_policy();
-  (*policy_ptr)[key] = rule;
+    std::string key = build_key(ns);
+    auto policy_ptr = mutable_string_policy();
+    (*policy_ptr)[key] = rule;
 }
 
 void ConfigPolicy::add_rule(const std::vector<std::string>& ns,
                             const IntRule& rule) {
-  std::string key = build_key(ns);
-  auto policy_ptr = mutable_integer_policy();
-  (*policy_ptr)[key]= rule;
+    std::string key = build_key(ns);
+    auto policy_ptr = mutable_integer_policy();
+    (*policy_ptr)[key]= rule;
 }
 
 void ConfigPolicy::add_rule(const std::vector<std::string>& ns,
                             const BoolRule& rule) {
-  std::string key = build_key(ns);
-  auto policy_ptr = mutable_bool_policy();
-  (*policy_ptr)[key] = rule;
+    std::string key = build_key(ns);
+    auto policy_ptr = mutable_bool_policy();
+    (*policy_ptr)[key] = rule;
 }
 
 Config::Config(const rpc::ConfigMap& config) : rpc_map(config) {}
@@ -62,27 +62,27 @@ Config::Config(const rpc::ConfigMap& config) : rpc_map(config) {}
 Config::~Config() {}
 
 bool Config::get_bool(const std::string& key) const {
-  auto bool_map = rpc_map.boolmap();
-  return bool_map.at(key);
+    auto bool_map = rpc_map.boolmap();
+    return bool_map.at(key);
 }
 
 int Config::get_int(const std::string& key) const {
-  auto int_map = rpc_map.intmap();
-  return int_map.at(key);
+    auto int_map = rpc_map.intmap();
+    return int_map.at(key);
 }
 
 std::string Config::get_string(const std::string& key) const {
-  auto str_map = rpc_map.stringmap();
-  return str_map.at(key);
+    auto str_map = rpc_map.stringmap();
+    return str_map.at(key);
 }
 
 static const std::string build_key(const std::vector<std::string>& ns) {
-  std::stringstream ss;
-  int i = 1;
-  for (std::string node : ns) {
-    if (i < ns.size()) ss << node << ".";
-    if (i == ns.size()) ss << node;
-    i++;
-  }
-  return ss.str();
+    std::stringstream ss;
+    int i = 1;
+    for (std::string node : ns) {
+        if (i < ns.size()) ss << node << ".";
+        if (i == ns.size()) ss << node;
+        i++;
+    }
+    return ss.str();
 }

--- a/src/snap/config.h
+++ b/src/snap/config.h
@@ -19,145 +19,143 @@ limitations under the License.
 #include <snap/rpc/plugin.pb.h>
 
 namespace Plugin {
+    template<class P, class R, typename T> class Rule;
 
-template<class P, class R, typename T> class Rule;
+    /**
+    * A Rule of type std::string
+    */
+    typedef Rule<rpc::StringPolicy, rpc::StringRule, std::string> StringRule;
 
-/**
- * A Rule of type std::string
- */
-typedef Rule<rpc::StringPolicy, rpc::StringRule, std::string> StringRule;
+    /**
+    * A Rule of type int
+    */
+    typedef Rule<rpc::IntegerPolicy, rpc::IntegerRule, int> IntRule;
 
-/**
- * A Rule of type int
- */
-typedef Rule<rpc::IntegerPolicy, rpc::IntegerRule, int> IntRule;
+    /**
+    * A Rule of type bool
+    */
+    typedef Rule<rpc::BoolPolicy, rpc::BoolRule, bool> BoolRule;
 
-/**
- * A Rule of type bool
- */
-typedef Rule<rpc::BoolPolicy, rpc::BoolRule, bool> BoolRule;
+    /**
+    * The Rule template.
+    * Config policy rules are made up of 2 sets of keys, and finally the structure
+    * describing the policy.
+    * Key 1: The namespace where this rule should be applied
+    *   Key 1 is only applicable for Collectors which are also providing metric
+    *   descriptors.
+    *   @see ConfigPolicy.
+    * Key 2: The key for the rule.  E.g. 'username', 'password', 'file_path', & c.
+    *
+    * Rule has a private, nested type which describes the policy.  Rule stores this
+    * Policy via the passed-in key. The Rule constructor cascades into rule's,
+    * then uses the key to point to the newly constructed rule.
+    */
+    template<class P, class R, typename T>
+    class Rule final : public P {
+    private:
+        class rule final : public R {
+        public:
+            rule() = delete;
+            explicit rule(bool req) {
+                this->set_required(req);
+            }
+            rule(const T& def, bool req) {
+                this->set_has_default(true);
+                this->set_default_(def);
+                this->set_required(req);
+            }
+            rule(const T& def, bool req, T min, T max) {
+                this->set_minimum(min);
+                this->set_maximum(max);
+                this->set_has_default(true);
+                this->set_default_(def);
+                this->set_required(req);
+            }
+            rule(bool req, T min, T max) {
+                this->set_minimum(min);
+                this->set_maximum(max);
+                this->set_required(req);
+            }
 
-/**
- * The Rule template.
- * Config policy rules are made up of 2 sets of keys, and finally the structure
- * describing the policy.
- * Key 1: The namespace where this rule should be applied
- *   Key 1 is only applicable for Collectors which are also providing metric
- *   descriptors.
- *   @see ConfigPolicy.
- * Key 2: The key for the rule.  E.g. 'username', 'password', 'file_path', & c.
- *
- * Rule has a private, nested type which describes the policy.  Rule stores this
- * Policy via the passed-in key. The Rule constructor cascades into rule's,
- * then uses the key to point to the newly constructed rule.
- */
-template<class P, class R, typename T>
-class Rule final : public P {
- private:
-  class rule final : public R {
-   public:
-    rule() = delete;
-    explicit rule(bool req) {
-      this->set_required(req);
-    }
-    rule(const T& def, bool req) {
-      this->set_has_default(true);
-      this->set_default_(def);
-      this->set_required(req);
-    }
-    rule(const T& def, bool req, T min, T max) {
-      this->set_minimum(min);
-      this->set_maximum(max);
-      this->set_has_default(true);
-      this->set_default_(def);
-      this->set_required(req);
-    }
-    rule(bool req, T min, T max) {
-      this->set_minimum(min);
-      this->set_maximum(max);
-      this->set_required(req);
-    }
+            ~rule() {}
+        };
 
-    ~rule() {}
-  };
+    public:
+        Rule() = delete;
 
- public:
-  Rule() = delete;
+        Rule(const std::string& key, const rule& rl) {
+            auto rule_ptr = this->mutable_rules();
+            (*rule_ptr)[key] = rl;
+        }
+        Rule(const std::string& key, bool req) {
+            rule rl(req);
+            auto rule_ptr = this->mutable_rules();
+            (*rule_ptr)[key] = rl;
+        }
 
-  Rule(const std::string& key, const rule& rl) {
-    auto rule_ptr = this->mutable_rules();
-    (*rule_ptr)[key] = rl;
-  }
-  Rule(const std::string& key, bool req) {
-    rule rl(req);
-    auto rule_ptr = this->mutable_rules();
-    (*rule_ptr)[key] = rl;
-  }
+        ~Rule() {}
+    };
 
-  ~Rule() {}
-};
+    /**
+    * A ConfigPolicy describes the requirements for running a given plugin.
+    * This policy is used to enforce that the required configuration is delivered
+    * to the plugin at runtime.
+    */
+    class ConfigPolicy final : public rpc::GetConfigPolicyReply {
+    public:
+        ConfigPolicy();
 
-/**
- * A ConfigPolicy describes the requirements for running a given plugin.
- * This policy is used to enforce that the required configuration is delivered
- * to the plugin at runtime.
- */
-class ConfigPolicy final : public rpc::GetConfigPolicyReply {
- public:
-  ConfigPolicy();
+        /**
+        * For Processor and Publisher plugins, there is no namespace to attach a
+        * rule to -- The rule is applied to the whole plugin.
+        * In those cases, these constructors are used.
+        */
+        explicit ConfigPolicy(const StringRule& rule);
+        explicit ConfigPolicy(const IntRule& rule);
+        explicit ConfigPolicy(const BoolRule& rule);
 
-  /**
-   * For Processor and Publisher plugins, there is no namespace to attach a
-   * rule to -- The rule is applied to the whole plugin.
-   * In those cases, these constructors are used.
-   */
-  explicit ConfigPolicy(const StringRule& rule);
-  explicit ConfigPolicy(const IntRule& rule);
-  explicit ConfigPolicy(const BoolRule& rule);
+        ~ConfigPolicy();
 
-  ~ConfigPolicy();
+        /**
+        * For Collector plugins, a config may be applied to a parent of a metric's
+        * namespace. Any metrics which fall underneath this prefix inherit the given
+        * rule.
+        */
+        void add_rule(const std::vector<std::string>& ns, const StringRule& rule);
+        void add_rule(const std::vector<std::string>& ns, const IntRule& rule);
+        void add_rule(const std::vector<std::string>& ns, const BoolRule& rule);
+    };
 
-  /**
-   * For Collector plugins, a config may be applied to a parent of a metric's
-   * namespace. Any metrics which fall underneath this prefix inherit the given
-   * rule.
-   */
-  void add_rule(const std::vector<std::string>& ns, const StringRule& rule);
-  void add_rule(const std::vector<std::string>& ns, const IntRule& rule);
-  void add_rule(const std::vector<std::string>& ns, const BoolRule& rule);
-};
+    /**
+    * Config is the incoming configuration data which has been vetted by snapteld
+    * according to the plugin's ConfigPolicy.
+    *
+    */
+    class Config {
+    public:
+        /**
+        * A config is immutable, and is always passed _to_ a Plugin Author's plugin,
+        * If one is constructed manually, any reads will be attempt to do `gets`
+        * against an unallocated pointer.  Deleting this constructor will block, at
+        * compile time, the ability to construct and use an incomplete config.
+        */
+        Config() = delete;
 
-/**
- * Config is the incoming configuration data which has been vetted by snapteld
- * according to the plugin's ConfigPolicy.
- *
- */
-class Config {
- public:
-   /**
-   * A config is immutable, and is always passed _to_ a Plugin Author's plugin,
-   * If one is constructed manually, any reads will be attempt to do `gets`
-   * against an unallocated pointer.  Deleting this constructor will block, at
-   * compile time, the ability to construct and use an incomplete config.
-   */
-  Config() = delete;
+        /**
+        * This library controls the lifetime of not only the Plugin::Config type,
+        * but also the rpc::ConfigMap it contains. This allows us hold a reference to
+        * the contained rpc::ConfigMap without using smart pointers or explicitly
+        * managing memory.
+        */
+        explicit Config(const rpc::ConfigMap&);
 
-  /**
-   * This library controls the lifetime of not only the Plugin::Config type,
-   * but also the rpc::ConfigMap it contains. This allows us hold a reference to
-   * the contained rpc::ConfigMap without using smart pointers or explicitly
-   * managing memory.
-   */
-  explicit Config(const rpc::ConfigMap&);
+        ~Config();
 
-  ~Config();
+        bool get_bool(const std::string& key) const;
+        int get_int(const std::string& key) const;
+        std::string get_string(const std::string& key) const;
 
-  bool get_bool(const std::string& key) const;
-  int get_int(const std::string& key) const;
-  std::string get_string(const std::string& key) const;
-
- private:
-  const rpc::ConfigMap& rpc_map;
-};
-
+        private:
+        const rpc::ConfigMap& rpc_map;
+    };
 };  // namespace Plugin

--- a/src/snap/flags.cc
+++ b/src/snap/flags.cc
@@ -1,0 +1,440 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2017 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <map>
+#include <iostream>
+
+#include <boost/any.hpp>
+#include <spdlog/spdlog.h>
+
+#include "snap/flags.h"
+
+// Set default option values
+// Default global flags:
+#define LISTEN_PORT ""
+#define LISTEN_ADDR "127.0.0.1"
+#define LOG_LEVEL 2
+#define CERT_PATH ""
+#define KEY_PATH ""
+#define ROOT_CERT_PATHS "::"
+#define STAND_ALONE_PORT 8182
+#define MAX_COLLECT_DURATION 10
+#define MAX_METRICS_BUFFER 0
+
+// Default hidden flags:
+#define OPTIONS_FILE "options.cfg"
+
+namespace po = boost::program_options;
+namespace spd = spdlog;
+// Group of options allowed only on command line
+int Plugin::Flags::addDefaultCommandFlags() {
+    try {
+        _command.add_options()
+            ("help,h", "Display available command-line options")
+            ("version,v", "Print the version");
+        return 0;
+    } 
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::addDefaultGlobalFlags() {
+    try {
+        // Declare group of options
+        // allowed both on command line and in config file
+        _global.add_options()
+            ("config", po::value<std::string>()->composing(), "Config to use in JSON format")
+            ("port", po::value<std::string>(&_listen_port)->default_value(LISTEN_PORT), "Port GRPC will listen on")
+            ("addr", po::value<std::string>(&_listen_addr)->default_value(LISTEN_ADDR), "addr GRPC will listen on")
+            ("log-level", po::value<int>(&_log_level)->default_value(LOG_LEVEL), 
+                "0:Panic 1:Fatal 2:Error 3:Warn 4:Info 5:Debug")
+            ("pprof", "Enable pprof")
+            ("tls", "Enable TLS")
+            ("cert-path", po::value<std::string>(&_cert_path)->default_value(CERT_PATH), "Necessary to provide when TLS enabled")
+            ("key-path", po::value<std::string>(&_key_path)->default_value(KEY_PATH), "Necessary to provide when TLS enabled")
+            ("root-cert-paths", po::value<std::string>(&_root_cert_paths)->default_value(ROOT_CERT_PATHS), "Root paths separator")
+            ("stand-alone", "Enable stand-alone plugin")
+            ("stand-alone-port", po::value<int>(&_stand_alone_port)->default_value(STAND_ALONE_PORT),
+                "Specify http port when stand-alone is set")
+            ("max-collect-duration", po::value<int>(&_max_collect_duration)->default_value(MAX_COLLECT_DURATION),
+                "In seconds, sets the maximum duration (always greater than 0s) between collections before metrics are sent")
+            ("max-metrics-buffer", po::value<int64_t>(&_max_metrics_buffer)->default_value(MAX_METRICS_BUFFER),
+                "Maximum number of metrics the plugin is buffering before sending metrics");
+        _config_file.add(_global);
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::addDefaultHiddenFlags() {
+    try {
+        _hidden.add_options()
+                ("options-file", po::value<string>(&_options_file)->default_value(OPTIONS_FILE),
+                    "name of file for options configuration");
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::SetDefaultFlags() {
+    try {
+        if (addDefaultCommandFlags() != 0) return 1;
+        if (addDefaultGlobalFlags() != 0) return 1;
+        if (addDefaultHiddenFlags() != 0) return 1;
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::addBoolFlag(const char *optionName, const char *description,
+                                Plugin::Flags::FlagLevel flagLevel) {
+    try {
+        switch (flagLevel) {
+        case Command:
+            _command.add_options()
+                    (optionName, description);
+            break;
+        case Global:
+            _global.add_options()
+                    (optionName, description);
+            break;
+        case Hidden:
+            _hidden.add_options()
+                    (optionName, description);
+            break;
+        case Custom:
+            _additional.add_options()
+                    (optionName, description);
+            break;
+        default:
+            _logger->warn("Flag level not supported");
+            return 1;
+        }
+        return 0;
+    } 
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+int Plugin::Flags::addIntFlag(const char *optionName, const char *description,
+                                FlagLevel flagLevel) {
+    try {
+        switch (flagLevel) {
+        case Command:
+            _command.add_options()
+                    (optionName, po::value<int>()->composing(), description);
+            break;
+        case Global:
+            _global.add_options()
+                    (optionName, po::value<int>()->composing(), description);
+            break;
+        case Hidden:
+            _hidden.add_options()
+                    (optionName, po::value<int>()->composing(), description);
+            break;
+        case Custom:
+            _additional.add_options()
+                    (optionName, po::value<int>()->composing(), description);
+            break;
+        default:
+            _logger->warn("Flag level not supported");
+            return 1;
+        }
+        return 0;
+    } 
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::addStringFlag(const char *optionName, const char *description,
+                                FlagLevel flagLevel) {
+                            try {
+        switch (flagLevel) {
+        case Command:
+            _command.add_options()
+                    (optionName, po::value<std::string>()->composing(), description);
+            break;
+        case Global:
+            _global.add_options()
+                    (optionName, po::value<std::string>()->composing(), description);
+            break;
+        case Hidden:
+            _hidden.add_options()
+                    (optionName, po::value<std::string>()->composing(), description);
+            break;
+        case Custom:
+            _additional.add_options()
+                    (optionName, po::value<std::string>()->composing(), description);
+            break;
+        default:
+            _logger->warn("Flag level not supported");
+            return 1;
+        }
+        return 0;
+    } 
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+// Declare group of options allowed only on command line
+int Plugin::Flags::AddFlag(const char * optionName, const char * description, 
+                            FlagType flagType, Plugin::Flags::FlagLevel flagLevel) {
+    try {
+        switch (flagType) {
+        case Bool:
+            return addBoolFlag(optionName, description, flagLevel);
+        case Int:
+            return addIntFlag(optionName, description, flagLevel);
+        case String:
+            return addStringFlag(optionName, description, flagLevel);
+        default:
+            _logger->warn("Flag type not supported");
+            return 1;
+        }
+        return 0;
+    } 
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::setVisibleFlags() {
+    try {
+        _visible.add(_command).add(_global).add(_additional);
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::setCommandLineFlags() {
+    try {
+        _command_line.add(_command).add(_global).add(_additional).add(_hidden);
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::setConfigFileFlags() {
+    try {
+        _config_file.add(_global).add(_additional);
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::SetCombinedFlags() {
+    try {
+        if (setVisibleFlags() != 0) return 1;
+        if (setCommandLineFlags() != 0) return 1;
+        if (setConfigFileFlags() != 0) return 1;
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::parseCommandLineFlags(const int &argc, char **argv) {
+    try {
+        po::store(po::command_line_parser(argc, argv).options(_command_line).run(), _flags);
+        po::notify(_flags);
+
+        if (_flags.count("help")) {
+            exit(helpFlagCalled());
+        }
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::parseConfigFileFlags(std::string filePathAndName /*=""*/) {
+    try {
+        ifstream ifs;
+        filePathAndName.empty() ? ifs.open(_options_file.c_str()) :
+            ifs.open(filePathAndName.c_str());
+        if (ifs) {
+            po::store(parse_config_file(ifs, _config_file), _flags);
+            po::notify(_flags);
+        }
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+int Plugin::Flags::ParseFlags(const int &argc, char **argv,
+                                std::string filePathAndName /*=""*/) {
+    try {
+        if (parseCommandLineFlags(argc, argv) != 0) return 1;
+        if (parseConfigFileFlags(filePathAndName) != 0) return 1;
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 1;
+    }
+}
+
+void Plugin::Flags::ShowVariablesMap() {
+    try {
+        for (const auto& it : _flags) {
+            std::cout << it.first.c_str() << " ";
+            auto& value = it.second.value();
+            if (auto v = boost::any_cast<bool>(&value))
+                std::cout << *v << std::endl;
+            else if (auto v = boost::any_cast<int>(&value))
+                std::cout << *v << std::endl;
+            else if (auto v = boost::any_cast<int64_t>(&value))
+                std::cout << *v << std::endl;
+            else if (auto v = boost::any_cast<std::string>(&value))
+                std::cout << *v << std::endl;
+            else
+                _logger->warn("variable map value type not supported");
+        }
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+    }
+}
+
+bool Plugin::Flags::GetFlagBoolValue(const char *flagKey) {
+    try {
+        if (_flags.count(flagKey)) {
+            auto &value = _flags[flagKey].value();
+            if (auto v = boost::any_cast<bool>(&value)) {
+                return *v;
+            }
+        }
+
+        _logger->warn("{0} is not a bool type", flagKey);
+        return false;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return false;
+    }
+}
+
+int Plugin::Flags::GetFlagIntValue(const char *flagKey) {
+    try {
+        if (_flags.count(flagKey)) {
+            auto &value = _flags[flagKey].value();
+            if (auto v = boost::any_cast<int>(&value)) {
+                return *v;
+            }
+        }
+        _logger->warn("{0} is not an int type", flagKey);
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 0;
+    }
+}
+
+int64_t Plugin::Flags::GetFlagInt64Value(const char *flagKey) {
+    try {
+        if (_flags.count(flagKey)) {
+            auto &value = _flags[flagKey].value();
+            if (auto v = boost::any_cast<int64_t>(&value)) {
+                return *v;
+            }
+        }
+        _logger->warn("{0} is not an int64 type", flagKey);
+        return 0;
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return 0;
+    }
+}
+
+std::string Plugin::Flags::GetFlagStrValue(const char *flagKey) {
+    try {
+        if (_flags.count(flagKey)) {
+            auto &value = _flags[flagKey].value();
+            if (auto v = boost::any_cast<std::string>(&value)) {
+                return *v;
+            }
+        }
+        _logger->warn("{0} is not a string type", flagKey);
+        return "";
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+        return "";
+    }
+}
+
+void Plugin::Flags::SetFlagsLogLevel(const int &logLevel /*=2*/) {
+    try {
+        switch (logLevel) {
+        case 0/*Panic*/:
+            _logger->set_level(spd::level::critical);
+            break;
+        case 1/*Fatal*/: 
+            _logger->set_level(spd::level::critical);
+            break;
+        case 2/*Error*/:
+            _logger->set_level(spd::level::err);
+            break;
+        case 3/*Warn*/: 
+            _logger->set_level(spd::level::warn);
+            break;
+        case 4/*Info*/:
+            _logger->set_level(spd::level::info);
+            break;
+        case 5/*Debug*/:
+            _logger->set_level(spd::level::debug);
+            break;
+        default:
+            _logger->warn("log level {0} not supported", logLevel);
+            break;
+        }
+    }
+    catch (std::exception &e) {
+        _logger->error(e.what());
+    }
+}

--- a/src/snap/flags.h
+++ b/src/snap/flags.h
@@ -1,0 +1,147 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright 2017 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#pragma once
+
+#include <boost/program_options.hpp>
+#include <iostream>
+#include <fstream>
+#include <iterator>
+#include <spdlog/spdlog.h>
+
+#define COMMAND_DESC "COMMANDS"
+#define GLOBAL_DESC "GLOBAL OPTIONS"
+#define ADDITIONAL_DESC ""
+
+namespace po = boost::program_options;
+namespace spd = spdlog;
+
+using namespace std;
+
+namespace Plugin {
+    //helper function to simplify main part
+    template<class T>
+    ostream& operator<<(ostream& os, const vector<T>& v) {
+        copy(v.begin(), v.end(), ostream_iterator<T>(os, " "));
+        return os;
+    };
+    
+    class Flags {
+    private:
+        std::shared_ptr<spd::logger> _logger;
+
+        po::variables_map _flags;
+        
+        // Initial option descriptions
+        po::options_description _command{COMMAND_DESC}, _global{GLOBAL_DESC};
+        po::options_description _hidden, _additional{ADDITIONAL_DESC};
+        
+        // Combined option descriptions
+        po::options_description _visible, _command_line, _config_file;
+
+        // Default variables
+        int _log_level, _stand_alone_port, _max_collect_duration;
+        std::string _options_file, _listen_port, _listen_addr, _cert_path, _key_path, _root_cert_paths;
+        int64_t _max_metrics_buffer;
+
+    public:
+        enum FlagType {
+            Bool,
+            Int,
+            String
+        };
+
+        enum FlagLevel {
+            Command,
+            Global,
+            Hidden,
+            Custom
+        };
+
+        Flags() {
+            _logger = spdlog::stdout_logger_mt("flags");
+        }
+
+        Flags(const int &argc, char **argv) {
+            _logger = spdlog::stdout_logger_mt("flags");
+            this->SetFlags();
+            this->ParseFlags(argc, argv);
+        }
+
+        int addDefaultCommandFlags();
+        int addDefaultGlobalFlags();
+        int addDefaultHiddenFlags();
+        int SetDefaultFlags();
+
+        int addBoolFlag(const char *optionName, const char *description,
+                        FlagLevel flagLevel);
+        int addIntFlag(const char *optionName, const char *description,
+                        FlagLevel flagLevel);
+        int addStringFlag(const char *optionName, const char *description,
+                        FlagLevel flagLevel);
+        int AddFlag(const char *optionName, const char *description, 
+                        FlagType flagType, FlagLevel flagLevel);
+
+        int setVisibleFlags();
+        int setCommandLineFlags();
+        int setConfigFileFlags();
+        int SetCombinedFlags();
+
+        int SetFlags() { 
+            if (SetDefaultFlags() != 0) return 1;
+            if (SetCombinedFlags() != 0) return 1;
+            return 0;
+        }
+
+        int parseCommandLineFlags(const int &argc, char **argv);
+        int parseConfigFileFlags(std::string filePathAndName = "");
+        int ParseFlags(const int &argc, char **argv, std::string filePathAndName = "");
+
+        void ShowVariablesMap();
+        bool IsParsedFlag(const char *flagKey) { return _flags.count(flagKey); }
+        po::variables_map GetFlagsVM() { return _flags; }
+
+        bool GetFlagBoolValue(const char *flagKey);
+        int GetFlagIntValue(const char *flagKey);
+        int64_t GetFlagInt64Value(const char *flagKey);
+        std::string GetFlagStrValue(const char *flagKey);
+
+        void SetFlagsLogLevel(const int &logLevel = 2);
+
+        int helpFlagCalled() {
+            std::cout << _visible << std::endl;
+            return 0;
+        }
+
+        po::options_description GetCommandOptions() { return _command; }
+        void PrintCommandOptions() { std::cout << _command << std::endl; }
+
+        po::options_description GetGlobalOptions() { return _global; }
+        void PrintGlobalOptions() { std::cout << _global << std::endl; }
+
+        po::options_description GetHiddenOptions() { return _hidden; }
+        void PrintHiddenOptions() { std::cout << _hidden << std::endl; }
+
+        po::options_description GetAdditionalOptions() { return _additional; }
+        void PrintAdditionalOptions() { std::cout << _additional << std::endl; }
+
+        po::options_description GetVisibleOptions() { return _visible; }
+        void PrintVisibleOptions() { std::cout << _visible << std::endl; }
+
+        po::options_description GetCommandLineOptions() { return _command_line; }
+        void PrintCommandLineOptions() { std::cout << _command_line << std::endl; }
+
+        po::options_description GetConfigFileOptions() { return _config_file; }
+        void PrintConfigFileOptions() { std::cout << _config_file << std::endl; }
+    };
+} // namespace Plugin

--- a/src/snap/grpc_export.cc
+++ b/src/snap/grpc_export.cc
@@ -23,8 +23,8 @@ limitations under the License.
 #include <string>
 
 #include <grpc++/grpc++.h>
-
 #include <json.hpp>
+#include <boost/network/protocol/http/server.hpp>
 
 #include "snap/rpc/plugin.pb.h"
 
@@ -48,81 +48,139 @@ using json = nlohmann::json;
 using Plugin::PluginInterface;
 using Plugin::Meta;
 
+namespace http = boost::network::http;
+
+typedef http::server<Plugin::GRPCExportImpl::handler_type> http_server;
+
+struct Plugin::GRPCExportImpl::handler_type {
+    std::string preamble;
+    void operator() (http_server::request const &request,
+                     http_server::response &response) {
+        response = http_server::response::stock_reply(
+            http_server::response::ok, this->preamble);
+    }
+
+    void log(http_server::string_type const &info) {
+        std::cerr << "Error: " << info << std::endl;
+    }
+};
+
 Plugin::GRPCExporter::GRPCExporter() : impl(std::shared_ptr<GRPCExportImpl>(implement())) {}
 
 future<void> Plugin::GRPCExporter::ExportPlugin(shared_ptr<PluginInterface> plugin, const Meta* meta) {
-  return this->impl->DoExport(plugin, meta);
+    return this->impl->DoExport(plugin, meta);
 }
 
 Plugin::GRPCExportImpl* Plugin::GRPCExporter::implement() {
-  return new GRPCExportImpl();
+    return new GRPCExportImpl();
 }
 
 future<void> Plugin::GRPCExportImpl::DoExport(shared_ptr<PluginInterface> plugin, const Meta *meta) {
-  this->plugin = std::move(plugin);
-  this->meta = meta;
-  doConfigure();
-  doRegister();
-  doAdvertise();
-  auto self = this->shared_from_this();
-  return std::async(std::launch::deferred, [=](){ self->doJoin(); });
+    this->plugin = std::move(plugin);
+    this->meta = meta;
+    doConfigure();
+    doRegister();
+    //_preamble = printPreamble();
+
+    if (this->meta->stand_alone) {
+        auto start_sa = std::async(std::launch::deferred, &Plugin::GRPCExportImpl::start_stand_alone, this,
+                                    this->meta->stand_alone_port);
+        start_sa.get();
+    }
+    else cout << printPreamble() << endl;
+    
+    auto self = this->shared_from_this();
+    return std::async(std::launch::deferred, [=](){ self->doJoin(); });
 }
 
 void Plugin::GRPCExportImpl::doConfigure() {
-  string server_address = "127.0.0.1:0";
+    std::stringstream ss;
+    ss << this->meta->listen_addr << ":";
+    this->meta->listen_port == "" ? ss << "0" : ss << this->meta->listen_port;
 
-  switch (plugin->GetType()) {
-    case Plugin::Collector:
-      this->service.reset(new Proxy::CollectorImpl(plugin->IsCollector()));
-      break;
-    case Plugin::Processor:
-      this->service.reset(new Proxy::ProcessorImpl(plugin->IsProcessor()));
-      break;
-    case Plugin::Publisher:
-      this->service.reset(new Proxy::PublisherImpl(plugin->IsPublisher()));
-      break;
-  }
-  builder.reset(new grpc::ServerBuilder());
-  builder->AddListeningPort(server_address, grpc::InsecureServerCredentials(),
-                           &this->port);
-
+    switch (plugin->GetType()) {
+        case Plugin::Collector:
+            this->service.reset(new Proxy::CollectorImpl(plugin->IsCollector()));
+            break;
+        case Plugin::Processor:
+            this->service.reset(new Proxy::ProcessorImpl(plugin->IsProcessor()));
+            break;
+        case Plugin::Publisher:
+            this->service.reset(new Proxy::PublisherImpl(plugin->IsPublisher()));
+            break;
+    }
+    
+    builder.reset(new grpc::ServerBuilder());
+    builder->AddListeningPort(ss.str(), grpc::InsecureServerCredentials(),
+                            &this->port);
 }
 
 void Plugin::GRPCExportImpl::doRegister() {
-  builder->RegisterService(service.get());
-  this->server = std::move(builder->BuildAndStart());
+    builder->RegisterService(service.get());
+    this->server = std::move(builder->BuildAndStart());
 }
 
-void Plugin::GRPCExportImpl::doAdvertise() {
-  std::stringstream ss;
-  ss << "127.0.0.1:" << port;
-  json j = {
-      {"Meta", {
-                   {"Type", meta->type},
-                   {"Name", meta->name},
-                   {"Version", meta->version},
-                   {"RPCType", meta->rpc_type},
-                   {"RPCVersion", RPC_VERSION},
-                   {"ConcurrencyCount", meta->concurrency_count},
-                   {"Exclusive", meta->exclusive},
+json Plugin::GRPCExportImpl::printPreamble() {
+    std::stringstream ss;
+    ss << meta->listen_addr << ":" << port;
 
-                   // The gRPC client in Snap does not use the `Unsecure` metadata key at
-                   // this time, as it is used for payload encryption.  With gRPC, encryption
-                   // is done via its transport, and this will be updated once support for
-                   // that feature lands in snapteld.
-                   {"Unsecure", true},
-                   {"CacheTTL", meta->cache_ttl.count()},
-                   {"RoutingStrategy", meta->strategy}
-               }},
-      {"ListenAddress", ss.str()},
-      {"Type", meta->type},
-      {"State", 0},
-      {"ErrMessage", ""},
-      {"Version", meta->version},
-  };
-  cout << j << endl;
+    json j = {
+        {"Meta", {
+                {"Type", meta->type},
+                {"Name", meta->name},
+                {"Version", meta->version},
+                {"RPCType", meta->rpc_type},
+                {"RPCVersion", RPC_VERSION},
+                {"ConcurrencyCount", meta->concurrency_count},
+                {"Exclusive", meta->exclusive},
+
+                // The gRPC client in Snap does not use the `Unsecure` metadata key at
+                // this time, as it is used for payload encryption.  With gRPC, encryption
+                // is done via its transport, and this will be updated once support for
+                // that feature lands in snapteld.
+                {"Unsecure", meta->unsecure},
+                {"CacheTTL", meta->cache_ttl.count()},
+                {"RoutingStrategy", meta->strategy},
+                {"PprofEnabled", meta->pprof_enabled},
+                {"TLSEnabled", meta->tls_enabled},
+                {"CertPath", meta->cert_path},
+                {"KeyPath", meta->key_path},
+                {"RootCertPaths", meta->root_cert_paths},
+                {"StandAloneEnabled", meta->stand_alone},
+                {"StandAlonePort", meta->stand_alone_port},
+                {"MaxCollectDuration", meta->max_collect_duration.count()},
+                {"MaxMetricsBuffer", meta->max_metrics_buffer},
+            }
+        },
+        {"ListenAddress", ss.str()},
+        {"Type", meta->type},
+        {"State", 0},
+        {"ErrMessage", ""},
+        {"Version", meta->version},
+    };
+    return j;
 }
 
 void Plugin::GRPCExportImpl::doJoin() {
-  server->Wait();
+    server->Wait();
+}
+
+int Plugin::GRPCExportImpl::start_stand_alone(const int &httpPort) {
+    try {
+        std::stringstream ss;
+        ss << printPreamble();
+  
+        handler_type _handler;
+        _handler.preamble = ss.str();
+        http_server::options options(_handler);
+        http_server _server(options.address("localhost").port(std::to_string(httpPort)));
+        std::cout << "Preamble URL: " << "localhost:" << httpPort << std::endl;
+        _server.run();
+    }
+    catch (std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
 }

--- a/src/snap/grpc_export.h
+++ b/src/snap/grpc_export.h
@@ -27,24 +27,25 @@ limitations under the License.
 #define RPC_VERSION 1
 
 namespace Plugin {
-class GRPCExportImpl;
+    class GRPCExportImpl;
 
-/**
- * Implementation of PluginExporter based on GRPC.
- */
-class GRPCExporter : public PluginExporter {
-public:
-  ~GRPCExporter() = default;
+    /**
+    * Implementation of PluginExporter based on GRPC.
+    */
+    class GRPCExporter : public PluginExporter {
+    public:
+        ~GRPCExporter() = default;
 
-  GRPCExporter(const GRPCExporter&) = delete;
-  GRPCExporter& operator=(const GRPCExporter&) = delete;
+        GRPCExporter(const GRPCExporter&) = delete;
+        GRPCExporter& operator=(const GRPCExporter&) = delete;
 
-  std::future<void> ExportPlugin(std::shared_ptr<PluginInterface> plugin, const Meta* meta);
-  GRPCExporter();
-protected:
-  GRPCExportImpl* implement();
-private:
-  std::shared_ptr<GRPCExportImpl> impl;
-};
+        std::future<void> ExportPlugin(std::shared_ptr<PluginInterface> plugin, const Meta* meta);
+        GRPCExporter();
 
+    protected:
+        GRPCExportImpl* implement();
+
+    private:
+        std::shared_ptr<GRPCExportImpl> impl;
+    };
 }

--- a/src/snap/grpc_export_impl.h
+++ b/src/snap/grpc_export_impl.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <vector>
 
 #include <grpc++/grpc++.h>
+#include <json.hpp>
 
 #include "snap/config.h"
 #include "snap/metric.h"
@@ -27,31 +28,33 @@ limitations under the License.
 #define RPC_VERSION 1
 
 namespace Plugin {
+    /*
+    * Implementation details for GRPC plugin exporter.
+    *
+    * Instance is supposed to be held referenced by shared pointer, to retain
+    * the resources (ie.: service and server).
+    */
+    class GRPCExportImpl : public std::enable_shared_from_this<GRPCExportImpl> {
+    public:
+        std::future<void> DoExport(std::shared_ptr<PluginInterface> plugin, const Meta* meta);
+        struct handler_type;
 
-/*
- * Implementation details for GRPC plugin exporter.
- *
- * Instance is supposed to be held referenced by shared pointer, to retain
- * the resources (ie.: service and server).
- */
-class GRPCExportImpl : public std::enable_shared_from_this<GRPCExportImpl> {
-public:
-  std::future<void> DoExport(std::shared_ptr<PluginInterface> plugin, const Meta* meta);
-protected:
-  int port;
-  std::shared_ptr<PluginInterface> plugin;
-  const Meta* meta;
-  std::unique_ptr<grpc::Service> service;
-  std::unique_ptr<grpc::ServerBuilder> builder;
-  std::unique_ptr<grpc::Server> server;
+    protected:
+        int port;
+        std::shared_ptr<PluginInterface> plugin;
+        const Meta* meta;
+        std::unique_ptr<grpc::Service> service;
+        std::unique_ptr<grpc::ServerBuilder> builder;
+        std::unique_ptr<grpc::Server> server;
 
-  /* steps of the export procedure */
-  void doConfigure();
-  void doRegister();
-  void doAdvertise();
+        /* steps of the export procedure */
+        void doConfigure();
+        void doRegister();
+        nlohmann::json printPreamble();
 
-  /* blocking method - waits for the server to finish. */
-  void doJoin();
-};
+        /* blocking method - waits for the server to finish. */
+        void doJoin();
 
+        int start_stand_alone(const int &httpPort);
+    };
 }

--- a/src/snap/lib_setup_impl.h
+++ b/src/snap/lib_setup_impl.h
@@ -24,12 +24,10 @@ limitations under the License.
 #define RPC_VERSION 1
 
 namespace Plugin {
-
-class LibSetup {
-public:
-  /* A provider of default PluginExporter - used only in static start_xxx methods.
-   * Returns independent instances per each invocation. */
-  static std::function<std::unique_ptr<Plugin::PluginExporter, std::function<void(Plugin::PluginExporter*)>>()> exporter_provider;
-};
-
+    class LibSetup {
+    public:
+    /* A provider of default PluginExporter - used only in static start_xxx methods.
+    * Returns independent instances per each invocation. */
+    static std::function<std::unique_ptr<Plugin::PluginExporter, std::function<void(Plugin::PluginExporter*)>>()> exporter_provider;
+    };
 };  // namespace Plugin

--- a/src/snap/metric.cc
+++ b/src/snap/metric.cc
@@ -30,152 +30,152 @@ using google::protobuf::RepeatedPtrField;
 using Plugin::Metric;
 
 Metric::Metric() : delete_metric_ptr(true),
-                   rpc_metric_ptr(new rpc::Metric),
-                   type(DataType::NotSet),
-                   config(Config(rpc_metric_ptr->config())) {}
+                rpc_metric_ptr(new rpc::Metric),
+                type(DataType::NotSet),
+                config(Config(rpc_metric_ptr->config())) {}
 
 Metric::Metric(std::vector<Metric::NamespaceElement> ns, std::string unit,
-               std::string description) :
-                 delete_metric_ptr(true),
-                 type(DataType::NotSet),
-                 rpc_metric_ptr(new rpc::Metric),
-                 config(Config(rpc_metric_ptr->config())) {
-  rpc_metric_ptr->set_unit(unit);
-  rpc_metric_ptr->set_description(description);
-  set_ns(ns);
+            std::string description) :
+                delete_metric_ptr(true),
+                type(DataType::NotSet),
+                rpc_metric_ptr(new rpc::Metric),
+                config(Config(rpc_metric_ptr->config())) {
+    rpc_metric_ptr->set_unit(unit);
+    rpc_metric_ptr->set_description(description);
+    set_ns(ns);
 }
 
 Metric::Metric(rpc::Metric* metric) :
-                 rpc_metric_ptr(metric),
-                 type(DataType::NotSet),
-                 delete_metric_ptr(false),
-                 config(Config(rpc_metric_ptr->config())) {}
+                rpc_metric_ptr(metric),
+                type(DataType::NotSet),
+                delete_metric_ptr(false),
+                config(Config(rpc_metric_ptr->config())) {}
 
 Metric::Metric(const Metric& from) : delete_metric_ptr(true),
-                                     config(from.config) {
-  rpc_metric_ptr = new rpc::Metric;
-  *rpc_metric_ptr = *from.rpc_metric_ptr;
+                                    config(from.config) {
+    rpc_metric_ptr = new rpc::Metric;
+    *rpc_metric_ptr = *from.rpc_metric_ptr;
 }
 
 Metric::~Metric() {
-  if (delete_metric_ptr) {
-    delete rpc_metric_ptr;
-  }
+    if (delete_metric_ptr) {
+        delete rpc_metric_ptr;
+    }
 }
 
 void Metric::set_ns(std::vector<Metric::NamespaceElement> ns) {
-  memo_ns.clear();
-  rpc_metric_ptr->clear_namespace_();
+    memo_ns.clear();
+    rpc_metric_ptr->clear_namespace_();
 
-  for (Metric::NamespaceElement ns_elem : ns) {
-    rpc::NamespaceElement* rpc_elem = rpc_metric_ptr->add_namespace_();
-    rpc_elem->set_name(ns_elem.name);
-    rpc_elem->set_value(ns_elem.value);
-    rpc_elem->set_description(ns_elem.description);
-    memo_ns.push_back({
-      rpc_elem->value(),
-      rpc_elem->name(),
-      rpc_elem->description(),
-    });
-  }
+    for (Metric::NamespaceElement ns_elem : ns) {
+        rpc::NamespaceElement* rpc_elem = rpc_metric_ptr->add_namespace_();
+        rpc_elem->set_name(ns_elem.name);
+        rpc_elem->set_value(ns_elem.value);
+        rpc_elem->set_description(ns_elem.description);
+        memo_ns.push_back({
+            rpc_elem->value(),
+            rpc_elem->name(),
+            rpc_elem->description()
+        });
+    }
 }
 
 const std::vector<Metric::NamespaceElement>& Metric::ns() const {
-  if (memo_ns.size() != 0) {
+    if (memo_ns.size() != 0) {
+        return memo_ns;
+    }
+
+    RepeatedPtrField<rpc::NamespaceElement> rpc_ns = rpc_metric_ptr->namespace_();
+    memo_ns.reserve(rpc_ns.size());
+
+    for (rpc::NamespaceElement rpc_elem : rpc_ns) {
+        memo_ns.push_back({
+            rpc_elem.value(),
+            rpc_elem.name(),
+            rpc_elem.description()
+        });
+    }
     return memo_ns;
-  }
-
-  RepeatedPtrField<rpc::NamespaceElement> rpc_ns = rpc_metric_ptr->namespace_();
-  memo_ns.reserve(rpc_ns.size());
-
-  for (rpc::NamespaceElement rpc_elem : rpc_ns) {
-    memo_ns.push_back({
-        rpc_elem.value(),
-        rpc_elem.name(),
-        rpc_elem.description()
-    });
-  }
-  return memo_ns;
 }
 
 std::vector<int> Metric::dynamic_ns_elements() const {
-  std::vector<int> idxs;
-  const std::vector<Metric::NamespaceElement>& namesp = ns();
-  int i = 0; 
-  for (auto element : namesp) {
-    if (!element.name.empty()) {
-      idxs.push_back(i);    
+    std::vector<int> idxs;
+    const std::vector<Metric::NamespaceElement>& namesp = ns();
+    int i = 0; 
+    for (auto element : namesp) {
+        if (!element.name.empty()) {
+            idxs.push_back(i);    
+        }
+        i++;
     }
-    i++;
-  }
-  return idxs;
+    return idxs;
 }
 
 void Metric::add_tag(std::pair<std::string, std::string> pair) {
-  // invalidate memoized tags.
-  std::map<std::string, std::string> memo_tags;
-  Map<std::string, std::string>* rpc_tags = rpc_metric_ptr->mutable_tags();
-  (*rpc_tags)[pair.first] = pair.second;
+    // invalidate memoized tags.
+    std::map<std::string, std::string> memo_tags;
+    Map<std::string, std::string>* rpc_tags = rpc_metric_ptr->mutable_tags();
+    (*rpc_tags)[pair.first] = pair.second;
 }
 
 const std::map<std::string, std::string>& Metric::tags() const {
-  if (memo_tags.size() != 0) {
+    if (memo_tags.size() != 0) {
+        return memo_tags;
+    }
+    const Map<std::string, std::string>& rpc_tags = rpc_metric_ptr->tags();
+    memo_tags = std::map<std::string, std::string>(rpc_tags.begin(),
+                                                    rpc_tags.end());
     return memo_tags;
-  }
-  const Map<std::string, std::string>& rpc_tags = rpc_metric_ptr->tags();
-  memo_tags = std::map<std::string, std::string>(rpc_tags.begin(),
-                                                 rpc_tags.end());
-  return memo_tags;
 }
 
 /**
- * rpc::Time is a structure containing seconds and nanoseconds. To retrieve an
- * accurate timestamp, these two counters must be summed.
- */
+* rpc::Time is a structure containing seconds and nanoseconds. To retrieve an
+* accurate timestamp, these two counters must be summed.
+*/
 system_clock::time_point Metric::timestamp() const {
-  // retrieve the tpc::Time
-  rpc::Time rpc_tm = rpc_metric_ptr->timestamp();
+    // retrieve the tpc::Time
+    rpc::Time rpc_tm = rpc_metric_ptr->timestamp();
 
-  // Convert the seconds member to a timepoint.
-  system_clock::time_point tp(seconds(rpc_tm.sec()));
+    // Convert the seconds member to a timepoint.
+    system_clock::time_point tp(seconds(rpc_tm.sec()));
 
-  // retrieve and convert the nanoseconds from rpc_tm to a nanoseconds duration.
-  nanoseconds rpc_nano_dur = nanoseconds(rpc_tm.nsec());
+    // retrieve and convert the nanoseconds from rpc_tm to a nanoseconds duration.
+    nanoseconds rpc_nano_dur = nanoseconds(rpc_tm.nsec());
 
-  // add the rpc nanoseconds to tp.
-  return (tp + rpc_nano_dur);
+    // add the rpc nanoseconds to tp.
+    return (tp + rpc_nano_dur);
 }
 
 void Metric::set_timestamp() {
-  auto now = system_clock::now();
-  set_ts(now);
+    auto now = system_clock::now();
+    set_ts(now);
 }
 
 void Metric::set_timestamp(system_clock::time_point tp) {
-  set_ts(tp);
+    set_ts(tp);
 }
 
 void Metric::set_last_advertised_time() {
-  auto now = system_clock::now();
-  set_last_advert_tm(now);
+    auto now = system_clock::now();
+    set_last_advert_tm(now);
 }
 
 void Metric::set_last_advertised_time(system_clock::time_point tp) {
-  set_last_advert_tm(tp);
+    set_last_advert_tm(tp);
 }
 
 Metric::DataType Metric::data_type() {
-  return (Metric::DataType)rpc_metric_ptr->data_case();
+    return (Metric::DataType)rpc_metric_ptr->data_case();
 }
 
 void Metric::set_data(float data) {
-  type = DataType::Float32;
-  rpc_metric_ptr->set_float32_data(data);
+    type = DataType::Float32;
+    rpc_metric_ptr->set_float32_data(data);
 }
 
 void Metric::set_data(double data) {
-  type = DataType::Float64;
-  rpc_metric_ptr->set_float64_data(data);
+    type = DataType::Float64;
+    rpc_metric_ptr->set_float64_data(data);
 }
 
 void Metric::set_data(int32_t data) {
@@ -204,8 +204,8 @@ void Metric::set_data(bool data) {
 }
 
 void Metric::set_data(const std::string& data) {
-  type = DataType::String;
-  rpc_metric_ptr->set_string_data(data);
+    type = DataType::String;
+    rpc_metric_ptr->set_string_data(data);
 }
 
 int32_t Metric::get_int_data() const {
@@ -225,11 +225,11 @@ uint64_t Metric::get_uint64_data() const {
 }
 
 float Metric::get_float32_data() const {
-  return rpc_metric_ptr->float32_data();
+    return rpc_metric_ptr->float32_data();
 }
 
 double Metric::get_float64_data() const {
-  return rpc_metric_ptr->float64_data();
+    return rpc_metric_ptr->float64_data();
 }
 
 bool Metric::get_bool_data() const {
@@ -237,29 +237,29 @@ bool Metric::get_bool_data() const {
 }
 
 const std::string& Metric::get_string_data() const {
-  return rpc_metric_ptr->string_data();
+    return rpc_metric_ptr->string_data();
 }
 
 Plugin::Config Metric::get_config() const {
-  return config;
+    return config;
 }
 
 const rpc::Metric* Metric::get_rpc_metric_ptr() const {
-  return rpc_metric_ptr;
+    return rpc_metric_ptr;
 }
 
 void Metric::set_ts(system_clock::time_point tp) {
-  rpc::Time* tm = rpc_metric_ptr->mutable_timestamp();
-  uint64_t nanos = uint64_t(duration_cast<nanoseconds>(
-                         tp.time_since_epoch()).count());
-  tm->set_sec(nanos / std::nano::den);
-  tm->set_nsec(nanos % std::nano::den);
+    rpc::Time* tm = rpc_metric_ptr->mutable_timestamp();
+    uint64_t nanos = uint64_t(duration_cast<nanoseconds>(
+                            tp.time_since_epoch()).count());
+    tm->set_sec(nanos / std::nano::den);
+    tm->set_nsec(nanos % std::nano::den);
 }
 
 void Metric::Metric::set_last_advert_tm(system_clock::time_point tp) {
-  rpc::Time* tm = rpc_metric_ptr->mutable_lastadvertisedtime();
-  uint64_t nanos = uint64_t(duration_cast<nanoseconds>(
-                         tp.time_since_epoch()).count());
-  tm->set_sec(nanos / std::nano::den);
-  tm->set_nsec(nanos % std::nano::den);
+    rpc::Time* tm = rpc_metric_ptr->mutable_lastadvertisedtime();
+    uint64_t nanos = uint64_t(duration_cast<nanoseconds>(
+                            tp.time_since_epoch()).count());
+    tm->set_sec(nanos / std::nano::den);
+    tm->set_nsec(nanos % std::nano::den);
 }

--- a/src/snap/metric.h
+++ b/src/snap/metric.h
@@ -25,175 +25,172 @@ limitations under the License.
 #include "snap/config.h"
 
 namespace Plugin {
-
-/**
- * Metric is the representation of a Metric inside Snap.
- */
-class Metric final {
- public:
-  /**
-   * A PODS describing an element in a metric namespace.
-   */
-  struct NamespaceElement {
     /**
-     * value is the static value of this node in a namespace.
-     * When a namespace element is _not_ dynamic, value is used. During
-     * metric collection, value should contain the static name for this metric.
-     */
-    std::string value;
-
+    * Metric is the representation of a Metric inside Snap.
+    */
+    class Metric final {
+    public:
     /**
-     * name is used to describe what this dynamic element is querying against.
-     * E.g. in the namespace `/intel/kvm/[vm_id]/cpu_wait` the element at index
-     * 2 has the name "vm_id".
-     * @see value
-     */
-    std::string name;
+    * A PODS describing an element in a metric namespace.
+    */
+        struct NamespaceElement {
+            /**
+            * value is the static value of this node in a namespace.
+            * When a namespace element is _not_ dynamic, value is used. During
+            * metric collection, value should contain the static name for this metric.
+            */
+            std::string value;
 
-    /**
-     * description is the description of this namespace element.
-     */
-    std::string description;
-  };
+            /**
+            * name is used to describe what this dynamic element is querying against.
+            * E.g. in the namespace `/intel/kvm/[vm_id]/cpu_wait` the element at index
+            * 2 has the name "vm_id".
+            * @see value
+            */
+            std::string name;
 
-  enum DataType {
-    String = rpc::Metric::DataCase::kStringData,
-    Float32 = rpc::Metric::DataCase::kFloat32Data,
-    Float64 = rpc::Metric::DataCase::kFloat64Data,
-    Int32 = rpc::Metric::DataCase::kInt32Data,
-    Int64 = rpc::Metric::DataCase::kInt64Data,
-    Uint32 = rpc::Metric::DataCase::kUint32Data,
-    Uint64 = rpc::Metric::DataCase::kUint64Data,
-    Bool = rpc::Metric::DataCase::kBoolData,
-    NotSet = rpc::Metric::DataCase::DATA_NOT_SET,
+            /**
+            * description is the description of this namespace element.
+            */
+            std::string description;
+        };
 
-  };
+        enum DataType {
+            String = rpc::Metric::DataCase::kStringData,
+            Float32 = rpc::Metric::DataCase::kFloat32Data,
+            Float64 = rpc::Metric::DataCase::kFloat64Data,
+            Int32 = rpc::Metric::DataCase::kInt32Data,
+            Int64 = rpc::Metric::DataCase::kInt64Data,
+            Uint32 = rpc::Metric::DataCase::kUint32Data,
+            Uint64 = rpc::Metric::DataCase::kUint64Data,
+            Bool = rpc::Metric::DataCase::kBoolData,
+            NotSet = rpc::Metric::DataCase::DATA_NOT_SET,
+        };
 
-  Metric();
-  /**
-   * The typical metric constructor.
-   * @param ns The metric's namespace.
-   * @param unit The metric's unit.
-   * @param description The metric's description.
-   */
-  Metric(std::vector<NamespaceElement> ns, std::string unit,
-         std::string description);
+        Metric();
+        /**
+        * The typical metric constructor.
+        * @param ns The metric's namespace.
+        * @param unit The metric's unit.
+        * @param description The metric's description.
+        */
+        Metric(std::vector<NamespaceElement> ns, std::string unit,
+                std::string description);
 
-  /**
-   * This constructor is used in the plugin proxies.
-   * It's used to wrap the rpc::Metric and rpc::ConfigMap types with the metric
-   * type from this library.
-   */
-  explicit Metric(rpc::Metric* metric);
+        /**
+        * This constructor is used in the plugin proxies.
+        * It's used to wrap the rpc::Metric and rpc::ConfigMap types with the metric
+        * type from this library.
+        */
+        explicit Metric(rpc::Metric* metric);
 
-  Metric(const Metric& from);
+        Metric(const Metric& from);
 
-  ~Metric();
+        ~Metric();
 
-  /**
-   * ns returns the metric's namespace.
-   * If there is a memoized copy, that is returned. Else the namespace is
-   * copied into the cache then returned.
-   */
-  const std::vector<NamespaceElement>& ns() const;
+        /**
+        * ns returns the metric's namespace.
+        * If there is a memoized copy, that is returned. Else the namespace is
+        * copied into the cache then returned.
+        */
+        const std::vector<NamespaceElement>& ns() const;
 
-  /**
-   * dynamic_ns_elements returns the indices in the metric's namespace which
-   * are dynamic.
-   */
-  std::vector<int> dynamic_ns_elements() const;
+        /**
+        * dynamic_ns_elements returns the indices in the metric's namespace which
+        * are dynamic.
+        */
+        std::vector<int> dynamic_ns_elements() const;
 
-  /**
-   * set_ns sets the namespace of the metric in its `rpc::Metric` ptr.
-   * It also invalidates the memoization cache of the namespace if it is
-   * present.
-   * @see memo_ns
-   */
-  void set_ns(std::vector<NamespaceElement>);
+        /**
+        * set_ns sets the namespace of the metric in its `rpc::Metric` ptr.
+        * It also invalidates the memoization cache of the namespace if it is
+        * present.
+        * @see memo_ns
+        */
+        void set_ns(std::vector<NamespaceElement>);
 
-  /**
-   * tags returns the metric's tags.
-   * If there is a memoized copy, that is returned. Else the tags are copied
-   * into the cache then returned.
-   */
-  const std::map<std::string, std::string>& tags() const;
+        /**
+        * tags returns the metric's tags.
+        * If there is a memoized copy, that is returned. Else the tags are copied
+        * into the cache then returned.
+        */
+        const std::map<std::string, std::string>& tags() const;
 
-  /**
-   * set_ns adds tags to the metric in its `rpc::Metric` ptr.
-   * It also invalidates the memoization cache of the tags if it is
-   * present.
-   * @see memo_tags_ptr
-   */
-  void add_tag(std::pair<std::string, std::string>);
+        /**
+        * set_ns adds tags to the metric in its `rpc::Metric` ptr.
+        * It also invalidates the memoization cache of the tags if it is
+        * present.
+        * @see memo_tags_ptr
+        */
+        void add_tag(std::pair<std::string, std::string>);
 
-  /**
-   * timestamp returns the metric's collection timestamp.
-   */
-  std::chrono::system_clock::time_point timestamp() const;
-  /**
-   * set_timestamp sets the timestamp as now.
-   */
-  void set_timestamp();
+        /**
+        * timestamp returns the metric's collection timestamp.
+        */
+        std::chrono::system_clock::time_point timestamp() const;
+        /**
+        * set_timestamp sets the timestamp as now.
+        */
+        void set_timestamp();
 
-  /**
-   * set_timestamp sets the timestamp as tp.
-   * @param tp The timestamp to use.
-   */
-  void set_timestamp(std::chrono::system_clock::time_point tp);
+        /**
+        * set_timestamp sets the timestamp as tp.
+        * @param tp The timestamp to use.
+        */
+        void set_timestamp(std::chrono::system_clock::time_point tp);
 
-  /**
-   * set_last_advertised_time sets last_advertised_time as now.
-   */
-  void set_last_advertised_time();
+        /**
+        * set_last_advertised_time sets last_advertised_time as now.
+        */
+        void set_last_advertised_time();
 
-  /**
-   * set_last_advertised_time sets last_advertised_time as tp.
-   * @param tp The timestamp to use.
-   */
-  void set_last_advertised_time(std::chrono::system_clock::time_point tp);
+        /**
+        * set_last_advertised_time sets last_advertised_time as tp.
+        * @param tp The timestamp to use.
+        */
+        void set_last_advertised_time(std::chrono::system_clock::time_point tp);
 
-  DataType data_type();
+        DataType data_type();
 
-  /**
-   * set_data sets the metric instances data in the underlying rpc::Metric
-   * pointer.
-   */
-  void set_data(int32_t data);
-  void set_data(int64_t data);
-  void set_data(uint32_t data);
-  void set_data(uint64_t data);
-  void set_data(float data);
-  void set_data(double data);
-  void set_data(bool data);
-  void set_data(const std::string& data);
+        /**
+        * set_data sets the metric instances data in the underlying rpc::Metric
+        * pointer.
+        */
+        void set_data(int32_t data);
+        void set_data(int64_t data);
+        void set_data(uint32_t data);
+        void set_data(uint64_t data);
+        void set_data(float data);
+        void set_data(double data);
+        void set_data(bool data);
+        void set_data(const std::string& data);
 
-  /**
-   * Retrieve this metric's datapoint
-   */
-  int32_t get_int_data() const;
-  int64_t get_int64_data() const;
-  uint32_t get_uint32_data() const;
-  uint64_t get_uint64_data() const;
-  float get_float32_data() const;
-  double get_float64_data() const;
-  bool get_bool_data() const;
-  const std::string& get_string_data() const;
-  Config get_config() const;
-  const rpc::Metric* get_rpc_metric_ptr() const;
+        /**
+        * Retrieve this metric's datapoint
+        */
+        int32_t get_int_data() const;
+        int64_t get_int64_data() const;
+        uint32_t get_uint32_data() const;
+        uint64_t get_uint64_data() const;
+        float get_float32_data() const;
+        double get_float64_data() const;
+        bool get_bool_data() const;
+        const std::string& get_string_data() const;
+        Config get_config() const;
+        const rpc::Metric* get_rpc_metric_ptr() const;
 
- private:
-  rpc::Metric* rpc_metric_ptr;
-  Config config;
+        private:
+        rpc::Metric* rpc_metric_ptr;
+        Config config;
 
-  void inline set_ts(std::chrono::system_clock::time_point tp);
-  void inline set_last_advert_tm(std::chrono::system_clock::time_point tp);
+        void inline set_ts(std::chrono::system_clock::time_point tp);
+        void inline set_last_advert_tm(std::chrono::system_clock::time_point tp);
 
-  // memoized members
-  mutable std::vector<NamespaceElement> memo_ns;
-  mutable std::map<std::string, std::string> memo_tags;
+        // memoized members
+        mutable std::vector<NamespaceElement> memo_ns;
+        mutable std::map<std::string, std::string> memo_tags;
 
-  bool delete_metric_ptr;
-  DataType type;
-};
-
+        bool delete_metric_ptr;
+        DataType type;
+    };
 }   // namespace Plugin

--- a/src/snap/options.cfg
+++ b/src/snap/options.cfg
@@ -1,0 +1,63 @@
+#
+# Uncomment out option variables to change default values
+#
+
+# Option Name: config
+# Description: Config to use in JSON format:
+# Type: string
+#
+# config = 
+
+# Option Name: port
+# Description: Port GRPC will listen on:
+# Type: string
+#
+# port = 
+
+# Option Name: pprof
+# Description: Enable pprof
+# Type: bool
+#
+# pprof = 
+
+# Option Name: tls
+# Description: Enable TLS
+# Type: bool
+#
+# tls = 
+
+# Option Name: cert-path
+# Description: Necessary to provide when TLS enabled
+# Type: string
+#
+# cert-path = 
+
+# Option Name: key-path
+# Description: Necessary to provide when TLS enabled
+# Type: 
+#
+# key-path = 
+
+# Option Name: root-cert-paths
+# Description: Root path separator
+# Type: string
+#
+# root-cert-paths = 
+
+# Option Name: stand-alone
+# Description: Enable stand alone plugin
+# Type: bool
+#
+# stand-alone = 
+
+# Option Name: stand-alone-port
+# Description: Specify http port when stand-alone is set
+# Type: int
+#
+# stand-alone-port = 
+
+# Option Name: log-level
+# Description: log level - 0:panic 1:fatal 2:error 3:warn 4:info 5:debug
+# Type: int
+#
+# log-level = 

--- a/src/snap/plugin.h
+++ b/src/snap/plugin.h
@@ -21,224 +21,291 @@ limitations under the License.
 
 #include "snap/config.h"
 #include "snap/metric.h"
+#include "snap/flags.h"
 
 #define RPC_VERSION 1
 
 namespace Plugin {
 
-class CollectorInterface;
-class ProcessorInterface;
-class PublisherInterface;
+    class CollectorInterface;
+    class ProcessorInterface;
+    class PublisherInterface;
 
-/**
- * Type is the plugin type
- */
-enum Type {
-  Collector,
-  Processor,
-  Publisher
-};
+    /**
+    * Type is the plugin type
+    */
+    enum Type {
+        Collector,
+        Processor,
+        Publisher
+    };
 
-/**
- * RpcType is the rpc protocol the plugin should use.
- * Only GRPC is supported for C++.
- */
-enum RpcType {
-  GRPC = 2,
-};
+    /**
+    * RpcType is the rpc protocol the plugin should use.
+    * Only GRPC is supported for C++.
+    */
+    enum RpcType {
+        GRPC = 2,
+        GRPCStream = 3
+    };
 
-/**
- * Strategy is the routing and caching strategy this plugin requires.
- * A routing and caching Strategy is the method which snapteld uses to cache
- * metrics, and select the correct running instance of a plugin.
- */
-enum Strategy {
-  /**
-   * LRU: Least Recently Used.
-   * The default strategy.
-   */
-  LRU,
+    /**
+    * Strategy is the routing and caching strategy this plugin requires.
+    * A routing and caching Strategy is the method which snapteld uses to cache
+    * metrics, and select the correct running instance of a plugin.
+    */
+    enum Strategy {
+        /**
+        * LRU: Least Recently Used.
+        * The default strategy.
+        */
+        LRU,
 
-  /**
-   * Sticky: Sticky Running plugins have a 1:1 relationship to Tasks.
-   */
-  Sticky,
+        /**
+        * Sticky: Sticky Running plugins have a 1:1 relationship to Tasks.
+        */
+        Sticky,
 
-  /** ConfigBased: Bases routing decisions on the incoming config.
-   * The config based strategy hashes the incoming config data and
-   * uses it as a key to select a running plugin.  It can be useful for plugins
-   * which maintain a connection to a database, for instance.
-   */
-  ConfigBased
-};
+        /** ConfigBased: Bases routing decisions on the incoming config.
+        * The config based strategy hashes the incoming config data and
+        * uses it as a key to select a running plugin.  It can be useful for plugins
+        * which maintain a connection to a database, for instance.
+        */
+        ConfigBased
+    };
 
-/**
- * Meta is the metadata about the plugin.
- */
-struct Meta final {
- public:
-  Meta(Type type, std::string name, int version);
+    /**
+    * Meta is the metadata about the plugin.
+    */
+    struct Meta final {
+    public:
+        Meta(Type type, std::string name, int version);
+        Meta(Type type, std::string name, int version, Flags *flags);
 
-  Type type;
-  std::string name;
-  int version;
+        Type type;
+        std::string name;
+        int version;
 
-  /**
-   * The RpcType in use, defaults to RpcType::GRPC. There should be no need to change
-   * it.
-   */
-  RpcType rpc_type;
+        /**
+        * The RpcType in use, defaults to RpcType::GRPC. There should be no need to change
+        * it.
+        */
+        RpcType rpc_type;
 
-  /**
-   * concurrency_count is the max number of concurrent calls the plugin
-   * should take.  For example:
-   * If there are 5 tasks using the plugin and its concurrency count is 2,
-   * snapteld will keep 3 plugin instances running.
-   * Using concurrency_count overwrites the default value of (5).
-   */
-  int concurrency_count;
+        /**
+        * concurrency_count is the max number of concurrent calls the plugin
+        * should take.  For example:
+        * If there are 5 tasks using the plugin and its concurrency count is 2,
+        * snapteld will keep 3 plugin instances running.
+        * Using concurrency_count overwrites the default value of (5).
+        */
+        int concurrency_count;
 
-  /**
-   * exclusive == true results in a single instance of the plugin running
-   * regardless of the number of tasks using the plugin.
-   * Using exclusive overwrites the default value of (false).
-   */
-  bool exclusive;
-  /**
-   * snapteld caches metrics on the daemon side for a default of 500ms.
-   * CacheTTL overwrites the default value of (500ms).
-   */
-  std::chrono::milliseconds cache_ttl;
+        /**
+        * exclusive == true results in a single instance of the plugin running
+        * regardless of the number of tasks using the plugin.
+        * Using exclusive overwrites the default value of (false).
+        */
+        bool exclusive;
 
-  /**
-   * Strategy will override the routing strategy this plugin requires.
-   * The default routing strategy is Least Recently Used.
-   * Strategy overwrites the default value of (LRU).
-   */
-  Strategy strategy;
-};
+        /**
+        * Unsecure is a legacy value not used for grpc, but needed to avoid
+		* calling SetKey needlessly.
+        */
+        bool unsecure;
 
-/**
- * Base class for exceptions indicated by plugins.
- *
- * When thrown from any kind of plugin, the exception will be
- * propagated to and reported by Snap framework.
- */
-class PluginException : public std::runtime_error {
- public:
-  PluginException(const std::string& message);
-};
+        /**
+        * snapteld caches metrics on the daemon side for a default of 500ms.
+        * CacheTTL overwrites the default value of (500ms).
+        */
+        std::chrono::milliseconds cache_ttl;
 
-/**
- * PluginInterface is the interface implemented by ALL plugins.
- * Every plugin must implement get_config_policy.
- */
-class PluginInterface {
-public:
-  virtual ~PluginInterface() {}
-  virtual Type GetType() const = 0;
-  virtual CollectorInterface* IsCollector();
-  virtual ProcessorInterface* IsProcessor();
-  virtual PublisherInterface* IsPublisher();
+        /**
+        * Strategy will override the routing strategy this plugin requires.
+        * The default routing strategy is Least Recently Used.
+        * Strategy overwrites the default value of (LRU).
+        */
+        Strategy strategy;
 
-  virtual const ConfigPolicy get_config_policy() = 0;
-protected:
-  PluginInterface() = default;
+        /**
+        * Port GRPC will listen on
+        */
+        std::string listen_port;
 
-};
+        /**
+        * Address GRPC will listen on
+        */
+        std::string listen_addr;        
 
-/**
- * PluginExporter is the driver for exporting plugin as a service (e.g.: via
- * GRPC). It's supposed to export a single instance of a plugin - should not be
- * reused.
- *
- * PluginExporter can block waiting for plugin termination. Any resources
- * associated with export operation are retained until the blocking wait
- * completes or exporter instance is destroyed.
- *
- * Plugin Library offers default plugin export implementation based on GRPC, if
- * the static start_xxx methods are used.
- */
-class PluginExporter {
-public:
-  virtual ~PluginExporter() = default;
+        /**
+        * Enables pprof
+        */
+        bool pprof_enabled;
 
-  PluginExporter(const PluginExporter &) = delete;
-  PluginExporter& operator=(const PluginExporter &) = delete;
+        /**
+        * Enables TLS
+        */
+        bool tls_enabled;
 
-  /** Export plugin as a service, allow waiting for termination (via future). */
-  virtual std::future<void> ExportPlugin(std::shared_ptr<PluginInterface> plugin, const Meta* meta) = 0;
-protected:
-  PluginExporter() = default;
-};
+        /**
+        * Necessary to provide when TLS enabled
+        */
+        std::string cert_path;
 
-/**
- * The interface for a collector plugin.
- * A Collector is the source.
- * It is responsible for collecting metrics in the Snap pipeline.
- */
-class CollectorInterface : public PluginInterface {
-public:
-  Type GetType() const final;
-  CollectorInterface* IsCollector() final;
+        /**
+        * Necessary to provide when TLS enabled
+        */
+        std::string key_path;
 
-  /*
-   * (inherited from PluginInterface)
-   */
-  virtual const ConfigPolicy get_config_policy() = 0;
+        /**
+        * Root path separator
+        */
+        std::string root_cert_paths;
 
-  /*
-   * get_metric_types should report all the metrics this plugin can collect.
-   */
-  virtual std::vector<Metric> get_metric_types(Config cfg) = 0;
+        /**
+        * Enable stand-alone plugin
+        */
+        bool stand_alone;
 
-  /*
-   * collect_metrics is given a list of metrics to collect.
-   * It should collect and annotate each metric with the apropos context.
-   */
-  virtual void collect_metrics(std::vector<Metric> &metrics) = 0;
+        /**
+        * Specify http port when stand-alone plugin is enabled
+        */
+        int stand_alone_port;
 
-};
+        /**
+        * sets the maximum duration (always greater than 0s) between collections
+        * before metrics are sent. Defaults to 10s what means that after 10 seconds 
+        * no new metrics are received, the plugin should send whatever data it has
+        * in the buffer instead of waiting longer. (e.g. 5s)
+        */
+        std::chrono::seconds max_collect_duration;
 
-/**
- * The interface for a Processor plugin.
- * A Processor is an intermediary in the pipeline. It may decorate, filter, or
- * derive as data passes through Snap's pipeline.
- */
-class ProcessorInterface : public PluginInterface {
-public:
-  Type GetType() const final;
-  ProcessorInterface* IsProcessor() final;
+        /**
+        * maximum number of metrics the plugin is buffering before sending metrics.
+        * Defaults to zero what means send metrics immediately
+        */
+        int64_t max_metrics_buffer;
+    };
 
-  virtual void process_metrics(std::vector<Metric> &metrics,
-                               const Config& config) = 0;
-};
+    /**
+    * Base class for exceptions indicated by plugins.
+    *
+    * When thrown from any kind of plugin, the exception will be
+    * propagated to and reported by Snap framework.
+    */
+    class PluginException : public std::runtime_error {
+    public:
+        PluginException(const std::string& message);
+    };
 
-/**
- * The interface for a Publisher plugin.
- * A Publisher is the sink.
- * It sinks data into some external system.
- */
-class PublisherInterface : public PluginInterface {
-public:
-  Type GetType() const final;
-  PublisherInterface* IsPublisher() final;
+    /**
+    * PluginInterface is the interface implemented by ALL plugins.
+    * Every plugin must implement get_config_policy.
+    */
+    class PluginInterface {
+    public:
+        virtual ~PluginInterface() {}
+        virtual Type GetType() const = 0;
+        virtual CollectorInterface* IsCollector();
+        virtual ProcessorInterface* IsProcessor();
+        virtual PublisherInterface* IsPublisher();
 
-  virtual void publish_metrics(std::vector<Metric> &metrics,
-                               const Config& config) = 0;
-};
+        virtual const ConfigPolicy get_config_policy() = 0;
+    protected:
+        PluginInterface() = default;
+    };
 
-/**
- * These functions are called to start a plugin.
- * They export plugin using default PluginExporter based on GRPC:
- * construct the gRPC service and server, start them, and then
- * block forever.
- *
- * These functions do not manage the plugin instance passed as parameter -
- * caller's responsible for releasing the resources.
- */
-void start_collector(CollectorInterface* plg, const Meta& meta);
-void start_processor(ProcessorInterface* plg, const Meta& meta);
-void start_publisher(PublisherInterface* plg, const Meta& meta);
+    /**
+    * PluginExporter is the driver for exporting plugin as a service (e.g.: via
+    * GRPC). It's supposed to export a single instance of a plugin - should not be
+    * reused.
+    *
+    * PluginExporter can block waiting for plugin termination. Any resources
+    * associated with export operation are retained until the blocking wait
+    * completes or exporter instance is destroyed.
+    *
+    * Plugin Library offers default plugin export implementation based on GRPC, if
+    * the static start_xxx methods are used.
+    */
+    class PluginExporter {
+    public:
+        virtual ~PluginExporter() = default;
+
+        PluginExporter(const PluginExporter &) = delete;
+        PluginExporter& operator=(const PluginExporter &) = delete;
+
+        /** Export plugin as a service, allow waiting for termination (via future). */
+        virtual std::future<void> ExportPlugin(std::shared_ptr<PluginInterface> plugin, const Meta* meta) = 0;
+    protected:
+        PluginExporter() = default;
+    };
+
+    /**
+    * The interface for a collector plugin.
+    * A Collector is the source.
+    * It is responsible for collecting metrics in the Snap pipeline.
+    */
+    class CollectorInterface : public PluginInterface {
+    public:
+        Type GetType() const final;
+        CollectorInterface* IsCollector() final;
+
+        /*
+        * (inherited from PluginInterface)
+        */
+        virtual const ConfigPolicy get_config_policy() = 0;
+
+        /*
+        * get_metric_types should report all the metrics this plugin can collect.
+        */
+        virtual std::vector<Metric> get_metric_types(Config cfg) = 0;
+
+        /*
+        * collect_metrics is given a list of metrics to collect.
+        * It should collect and annotate each metric with the apropos context.
+        */
+        virtual void collect_metrics(std::vector<Metric> &metrics) = 0;
+    };
+
+    /**
+    * The interface for a Processor plugin.
+    * A Processor is an intermediary in the pipeline. It may decorate, filter, or
+    * derive as data passes through Snap's pipeline.
+    */
+    class ProcessorInterface : public PluginInterface {
+    public:
+        Type GetType() const final;
+        ProcessorInterface* IsProcessor() final;
+
+        virtual void process_metrics(std::vector<Metric> &metrics,
+                                    const Config& config) = 0;
+    };
+
+    /**
+    * The interface for a Publisher plugin.
+    * A Publisher is the sink.
+    * It sinks data into some external system.
+    */
+    class PublisherInterface : public PluginInterface {
+    public:
+        Type GetType() const final;
+        PublisherInterface* IsPublisher() final;
+
+        virtual void publish_metrics(std::vector<Metric> &metrics,
+                                    const Config& config) = 0;
+    };
+
+    /**
+    * These functions are called to start a plugin.
+    * They export plugin using default PluginExporter based on GRPC:
+    * construct the gRPC service and server, start them, and then
+    * block forever.
+    *
+    * These functions do not manage the plugin instance passed as parameter -
+    * caller's responsible for releasing the resources.
+    */
+    void start_collector(CollectorInterface* plg, const Meta& meta);
+    void start_processor(ProcessorInterface* plg, const Meta& meta);
+    void start_publisher(PublisherInterface* plg, const Meta& meta);
 
 };  // namespace Plugin

--- a/src/snap/proxy/collector_proxy.cc
+++ b/src/snap/proxy/collector_proxy.cc
@@ -40,75 +40,73 @@ using Plugin::Metric;
 using Plugin::Proxy::CollectorImpl;
 
 CollectorImpl::CollectorImpl(Plugin::CollectorInterface* plugin) :
-                             collector(plugin) {
-  plugin_impl_ptr = new PluginImpl(plugin);
+                                collector(plugin) {
+    plugin_impl_ptr = new PluginImpl(plugin);
 }
 
 CollectorImpl::~CollectorImpl() {
-  delete plugin_impl_ptr;
+    delete plugin_impl_ptr;
 }
 
 Status CollectorImpl::CollectMetrics(ServerContext* context,
-                                     const MetricsArg* req,
-                                     MetricsReply* resp) {
-  std::vector<Metric> metrics;
-  RepeatedPtrField<rpc::Metric> rpc_mets = req->metrics();
+                                    const MetricsArg* req,
+                                    MetricsReply* resp) {
+    std::vector<Metric> metrics;
+    RepeatedPtrField<rpc::Metric> rpc_mets = req->metrics();
 
-  for (int i = 0; i < rpc_mets.size(); i++) {
-    metrics.emplace_back(rpc_mets.Mutable(i));
-  }
+    for (int i = 0; i < rpc_mets.size(); i++) {
+        metrics.emplace_back(rpc_mets.Mutable(i));
+    }
 
-  try {
-   collector->collect_metrics(metrics);
+    try {
+        collector->collect_metrics(metrics);
 
-   for (Metric met : metrics) {
-     *resp->add_metrics() = *met.get_rpc_metric_ptr();
-   }
-   return Status::OK;
-  } catch (PluginException &e) {
-   resp->set_error(e.what());
-   return Status(StatusCode::UNKNOWN, e.what());
-  }
+        for (Metric met : metrics) {
+            *resp->add_metrics() = *met.get_rpc_metric_ptr();
+        }
+        return Status::OK;
+    } catch (PluginException &e) {
+        resp->set_error(e.what());
+        return Status(StatusCode::UNKNOWN, e.what());
+    }
 }
 
 Status CollectorImpl::GetMetricTypes(ServerContext* context,
-                                     const GetMetricTypesArg* req,
-                                     MetricsReply* resp) {
-  Plugin::Config cfg(req->config());
+                                    const GetMetricTypesArg* req,
+                                    MetricsReply* resp) {
+    Plugin::Config cfg(req->config());
 
-  try {
-   std::vector<Metric> metrics = collector->get_metric_types(cfg);
+    try {
+        std::vector<Metric> metrics = collector->get_metric_types(cfg);
 
-   for (Metric met : metrics) {
-     met.set_timestamp();
-     met.set_last_advertised_time();
-     *resp->add_metrics() = *met.get_rpc_metric_ptr();
-   }
-   return Status::OK;
-  } catch (PluginException &e) {
-   resp->set_error(e.what());
-   return Status(StatusCode::UNKNOWN, e.what());
-  }
-
+        for (Metric met : metrics) {
+            met.set_timestamp();
+            met.set_last_advertised_time();
+            *resp->add_metrics() = *met.get_rpc_metric_ptr();
+        }
+        return Status::OK;
+    } catch (PluginException &e) {
+        resp->set_error(e.what());
+        return Status(StatusCode::UNKNOWN, e.what());
+    }
 }
 
 Status CollectorImpl::Kill(ServerContext* context, const KillArg* req,
-                           ErrReply* resp) {
-  return plugin_impl_ptr->Kill(context, req, resp);
+                        ErrReply* resp) {
+    return plugin_impl_ptr->Kill(context, req, resp);
 }
 
 Status CollectorImpl::GetConfigPolicy(ServerContext* context, const Empty* req,
-                                      GetConfigPolicyReply* resp) {
-  try {
-   return plugin_impl_ptr->GetConfigPolicy(context, req, resp);
-  } catch (PluginException &e) {
-   resp->set_error(e.what());
-   return Status(StatusCode::UNKNOWN, e.what());
-  }
-
+                                    GetConfigPolicyReply* resp) {
+    try {
+        return plugin_impl_ptr->GetConfigPolicy(context, req, resp);
+    } catch (PluginException &e) {
+        resp->set_error(e.what());
+        return Status(StatusCode::UNKNOWN, e.what());
+    }
 }
 
 Status CollectorImpl::Ping(ServerContext* context, const Empty* req,
-                           ErrReply* resp) {
-  return plugin_impl_ptr->Ping(context, req, resp);
+                        ErrReply* resp) {
+    return plugin_impl_ptr->Ping(context, req, resp);
 }

--- a/src/snap/proxy/collector_proxy.h
+++ b/src/snap/proxy/collector_proxy.h
@@ -21,36 +21,34 @@ limitations under the License.
 #include "snap/proxy/plugin_proxy.h"
 
 namespace Plugin {
-namespace Proxy {
+    namespace Proxy {
+        class CollectorImpl final : public rpc::Collector::Service {
+        public:
+            explicit CollectorImpl(Plugin::CollectorInterface* plugin);
 
-class CollectorImpl final : public rpc::Collector::Service {
- public:
-  explicit CollectorImpl(Plugin::CollectorInterface* plugin);
+            ~CollectorImpl();
 
-  ~CollectorImpl();
+            grpc::Status CollectMetrics(grpc::ServerContext* context,
+                                        const rpc::MetricsArg* req,
+                                        rpc::MetricsReply* resp);
 
-  grpc::Status CollectMetrics(grpc::ServerContext* context,
-                              const rpc::MetricsArg* req,
-                              rpc::MetricsReply* resp);
+            grpc::Status GetMetricTypes(grpc::ServerContext* context,
+                                        const rpc::GetMetricTypesArg* request,
+                                        rpc::MetricsReply* resp);
 
-  grpc::Status GetMetricTypes(grpc::ServerContext* context,
-                              const rpc::GetMetricTypesArg* request,
-                              rpc::MetricsReply* resp);
+            grpc::Status Kill(grpc::ServerContext* context, const rpc::KillArg* request,
+                                rpc::ErrReply* response);
 
-  grpc::Status Kill(grpc::ServerContext* context, const rpc::KillArg* request,
-                    rpc::ErrReply* response);
+            grpc::Status GetConfigPolicy(grpc::ServerContext* context,
+                                        const rpc::Empty* request,
+                                        rpc::GetConfigPolicyReply* resp);
 
-  grpc::Status GetConfigPolicy(grpc::ServerContext* context,
-                               const rpc::Empty* request,
-                               rpc::GetConfigPolicyReply* resp);
+            grpc::Status Ping(grpc::ServerContext* context, const rpc::Empty* request,
+                                rpc::ErrReply* resp);
 
-  grpc::Status Ping(grpc::ServerContext* context, const rpc::Empty* request,
-                    rpc::ErrReply* resp);
-
- private:
-  Plugin::CollectorInterface* collector;
-  PluginImpl* plugin_impl_ptr;
-};
-
-}  // namespace Proxy
+        private:
+            Plugin::CollectorInterface* collector;
+            PluginImpl* plugin_impl_ptr;
+        };
+    }  // namespace Proxy
 }  // namespace Plugin

--- a/src/snap/proxy/plugin_proxy.cc
+++ b/src/snap/proxy/plugin_proxy.cc
@@ -11,10 +11,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#include "snap/proxy/plugin_proxy.h"
-
 #include <grpc++/grpc++.h>
+#include <iostream>
+#include <thread>
 
+#include "snap/proxy/plugin_proxy.h"
 #include "snap/rpc/plugin.pb.h"
 
 using grpc::Server;
@@ -32,16 +33,41 @@ PluginImpl::PluginImpl(Plugin::PluginInterface* plugin) : plugin(plugin) {}
 
 Status PluginImpl::Ping(ServerContext* context, const Empty* req,
                         ErrReply* resp) {
-  return Status::OK;
+    _lastPing = std::chrono::system_clock::now();
+    // Change to log
+    std::cout << "Heartbeat received at: " << _lastPing << std::endl;
+    return Status::OK;
 }
 
 Status PluginImpl::Kill(ServerContext* context, const KillArg* req,
                         ErrReply* resp) {
-  return Status::OK;
+    return Status::OK;
 }
 
 Status PluginImpl::GetConfigPolicy(ServerContext* context, const Empty* req,
                                    GetConfigPolicyReply* resp) {
-  *resp = plugin->get_config_policy();
-  return Status::OK;
+    *resp = plugin->get_config_policy();
+    return Status::OK;
+}
+
+void PluginImpl::HeartbeatWatch() {
+    _lastPing = std::chrono::system_clock::now();
+    std::cout << "Heartbeat started" << std::endl;
+    int count = 0;
+    while (1) {
+        if ((std::chrono::system_clock::now() - _lastPing).count() >= _pingTimeoutDuration.count()) {
+            ++count;
+            std::cout << "Heartbeat timeout " << count 
+                        << " of " << _pingTimeoutLimit 
+                        << ".  (Duration between checks " << _pingTimeoutDuration.count() << ")" << std::endl;
+            if (count >= _pingTimeoutLimit) {
+                std::cout << "Heartbeat timeout expired!" << std::endl;
+                exit(0);
+            }
+        } else {
+            std::cout << "Heartbeat timeout reset";
+            count = 0;
+        }
+        std::this_thread::sleep_for(_pingTimeoutDuration);
+    }
 }

--- a/src/snap/proxy/plugin_proxy.h
+++ b/src/snap/proxy/plugin_proxy.h
@@ -12,34 +12,61 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #pragma once
-
+#include <iostream>
+#include <chrono>
+#include <ctime>
+#include <iomanip>
 #include <grpc++/grpc++.h>
 
 #include "snap/rpc/plugin.pb.h"
-
 #include "snap/plugin.h"
 
 namespace Plugin {
-namespace Proxy {
+    namespace Proxy {
+        template<typename Clock, typename Duration>
+        std::ostream &operator<<(std::ostream &stream,
+        const std::chrono::time_point<Clock, Duration> &time_point) {
+            const time_t time = Clock::to_time_t(time_point);
+        #if __GNUC__ > 4 || \
+            ((__GNUC__ == 4) && __GNUC_MINOR__ > 8 && __GNUC_REVISION__ > 1)
+            // Maybe the put_time will be implemented later?
+            struct tm tm;
+            localtime_r(&time, &tm);
+            return stream << std::put_time(&tm, "%c"); // Print standard date&time
+        #else
+            char buffer[26];
+            ctime_r(&time, buffer);
+            buffer[24] = '\0';  // Removes the newline that is added
+            return stream << buffer;
+        #endif
+        }
 
-class PluginImpl final {
- public:
-  explicit PluginImpl(Plugin::PluginInterface* plugin);
+        class PluginImpl final {
+        public:
+            explicit PluginImpl(Plugin::PluginInterface* plugin);
 
-  grpc::Status Ping(grpc::ServerContext* context, const rpc::Empty* req,
-                    rpc::ErrReply* resp);
+            grpc::Status Ping(grpc::ServerContext* context, const rpc::Empty* req,
+                                rpc::ErrReply* resp);
 
 
-  grpc::Status Kill(grpc::ServerContext* context, const rpc::KillArg* req,
-                    rpc::ErrReply* response);
+            grpc::Status Kill(grpc::ServerContext* context, const rpc::KillArg* req,
+                                rpc::ErrReply* response);
 
-  grpc::Status GetConfigPolicy(grpc::ServerContext* context,
-                               const rpc::Empty* req,
-                               rpc::GetConfigPolicyReply* resp);
+            grpc::Status GetConfigPolicy(grpc::ServerContext* context,
+                                        const rpc::Empty* req,
+                                        rpc::GetConfigPolicyReply* resp);
 
- private:
-  Plugin::PluginInterface* plugin;
-};
+            void HeartbeatWatch();
 
-}  // namespace Proxy
+        private:
+            Plugin::PluginInterface* plugin;
+            std::chrono::system_clock::time_point _lastPing;
+            // PingTimeoutLimit is the number of successively missed pin health checks
+            // which must occur before the plugin is stopped
+            int _pingTimeoutLimit = 3;            
+            // PingTimeoutDuration is the duration during which a ping healthcheck
+            // should be received
+            std::chrono::seconds _pingTimeoutDuration{3}; 
+        };
+    }  // namespace Proxy
 }  // namespace Plugin

--- a/src/snap/proxy/processor_proxy.cc
+++ b/src/snap/proxy/processor_proxy.cc
@@ -38,52 +38,52 @@ using Plugin::Proxy::ProcessorImpl;
 
 ProcessorImpl::ProcessorImpl(Plugin::ProcessorInterface* plugin) :
                              processor(plugin) {
-  plugin_impl_ptr = new PluginImpl(plugin);
+    plugin_impl_ptr = new PluginImpl(plugin);
 }
 
 ProcessorImpl::~ProcessorImpl() {
-  delete plugin_impl_ptr;
+    delete plugin_impl_ptr;
 }
 
 Status ProcessorImpl::Process(ServerContext* context, const PubProcArg* req,
                               MetricsReply* resp) {
-  std::vector<Metric> metrics;
-  RepeatedPtrField<rpc::Metric> rpc_mets = req->metrics();
+    std::vector<Metric> metrics;
+    RepeatedPtrField<rpc::Metric> rpc_mets = req->metrics();
 
-  for (int i = 0; i < rpc_mets.size(); i++) {
-    metrics.emplace_back(rpc_mets.Mutable(i));
-  }
+    for (int i = 0; i < rpc_mets.size(); i++) {
+        metrics.emplace_back(rpc_mets.Mutable(i));
+    }
 
-  Plugin::Config config(req->config());
-  try {
-   processor->process_metrics(metrics, config);
+    Plugin::Config config(req->config());
+    try {
+        processor->process_metrics(metrics, config);
 
-   for (Metric met : metrics) {
-     *resp->add_metrics() = *met.get_rpc_metric_ptr();
-   }
-   return Status::OK;
-  } catch (PluginException &e) {
-   resp->set_error(e.what());
-   return Status(StatusCode::UNKNOWN, e.what());
-  }
+        for (Metric met : metrics) {
+            *resp->add_metrics() = *met.get_rpc_metric_ptr();
+        }
+        return Status::OK;
+    } catch (PluginException &e) {
+        resp->set_error(e.what());
+        return Status(StatusCode::UNKNOWN, e.what());
+    }
 }
 
 Status ProcessorImpl::Kill(ServerContext* context, const KillArg* req,
                            ErrReply* resp) {
-  return plugin_impl_ptr->Kill(context, req, resp);
+    return plugin_impl_ptr->Kill(context, req, resp);
 }
 
 Status ProcessorImpl::GetConfigPolicy(ServerContext* context, const Empty* req,
                                       GetConfigPolicyReply* resp) {
-  try {
-   return plugin_impl_ptr->GetConfigPolicy(context, req, resp);
-  } catch (PluginException &e) {
-   resp->set_error(e.what());
-   return Status(StatusCode::UNKNOWN, e.what());
-  }
+    try {
+        return plugin_impl_ptr->GetConfigPolicy(context, req, resp);
+    } catch (PluginException &e) {
+        resp->set_error(e.what());
+        return Status(StatusCode::UNKNOWN, e.what());
+    }
 }
 
 Status ProcessorImpl::Ping(ServerContext* context, const Empty* req,
                            ErrReply* resp) {
-  return plugin_impl_ptr->Ping(context, req, resp);
+    return plugin_impl_ptr->Ping(context, req, resp);
 }

--- a/src/snap/proxy/processor_proxy.h
+++ b/src/snap/proxy/processor_proxy.h
@@ -21,32 +21,30 @@ limitations under the License.
 #include "snap/proxy/plugin_proxy.h"
 
 namespace Plugin {
-namespace Proxy {
+    namespace Proxy {
+        class ProcessorImpl final : public rpc::Processor::Service {
+        public:
+            explicit ProcessorImpl(Plugin::ProcessorInterface* plugin);
 
-class ProcessorImpl final : public rpc::Processor::Service {
- public:
-  explicit ProcessorImpl(Plugin::ProcessorInterface* plugin);
+            ~ProcessorImpl();
 
-  ~ProcessorImpl();
+            grpc::Status Process(grpc::ServerContext* context,
+                                const rpc::PubProcArg* req,
+                                rpc::MetricsReply* resp);
 
-  grpc::Status Process(grpc::ServerContext* context,
-                       const rpc::PubProcArg* req,
-                       rpc::MetricsReply* resp);
+            grpc::Status Kill(grpc::ServerContext* context, const rpc::KillArg* request,
+                                rpc::ErrReply* response);
 
-  grpc::Status Kill(grpc::ServerContext* context, const rpc::KillArg* request,
-                    rpc::ErrReply* response);
+            grpc::Status GetConfigPolicy(grpc::ServerContext* context,
+                                        const rpc::Empty* request,
+                                        rpc::GetConfigPolicyReply* resp);
 
-  grpc::Status GetConfigPolicy(grpc::ServerContext* context,
-                               const rpc::Empty* request,
-                               rpc::GetConfigPolicyReply* resp);
+            grpc::Status Ping(grpc::ServerContext* context, const rpc::Empty* request,
+                                rpc::ErrReply* resp);
 
-  grpc::Status Ping(grpc::ServerContext* context, const rpc::Empty* request,
-                    rpc::ErrReply* resp);
-
- private:
-  Plugin::ProcessorInterface* processor;
-  PluginImpl* plugin_impl_ptr;
-};
-
-}   // namespace Proxy
+        private:
+            Plugin::ProcessorInterface* processor;
+            PluginImpl* plugin_impl_ptr;
+        };
+    }   // namespace Proxy
 }   // namespace Plugin

--- a/src/snap/proxy/publisher_proxy.cc
+++ b/src/snap/proxy/publisher_proxy.cc
@@ -37,48 +37,48 @@ using Plugin::Proxy::PublisherImpl;
 
 PublisherImpl::PublisherImpl(Plugin::PublisherInterface* plugin) :
                              publisher(plugin) {
-  plugin_impl_ptr = new PluginImpl(plugin);
+    plugin_impl_ptr = new PluginImpl(plugin);
 }
 
 PublisherImpl::~PublisherImpl() {
-  delete plugin_impl_ptr;
+    delete plugin_impl_ptr;
 }
 
 Status PublisherImpl::Publish(ServerContext* context, const PubProcArg* req,
                               ErrReply* resp) {
-  std::vector<Metric> metrics;
-  RepeatedPtrField<rpc::Metric> rpc_mets = req->metrics();
+    std::vector<Metric> metrics;
+    RepeatedPtrField<rpc::Metric> rpc_mets = req->metrics();
 
-  for (int i = 0; i < rpc_mets.size(); i++) {
-    metrics.emplace_back(rpc_mets.Mutable(i));
-  }
+    for (int i = 0; i < rpc_mets.size(); i++) {
+        metrics.emplace_back(rpc_mets.Mutable(i));
+    }
 
-  Plugin::Config config(req->config());
-  try {
-   publisher->publish_metrics(metrics, config);
-   return Status::OK;
-  } catch (PluginException &e) {
-   resp->set_error(e.what());
-   return Status(StatusCode::UNKNOWN, e.what());
-  }
+    Plugin::Config config(req->config());
+    try {
+        publisher->publish_metrics(metrics, config);
+        return Status::OK;
+    } catch (PluginException &e) {
+        resp->set_error(e.what());
+        return Status(StatusCode::UNKNOWN, e.what());
+    }
 }
 
 Status PublisherImpl::Kill(ServerContext* context, const KillArg* req,
                            ErrReply* resp) {
-  return plugin_impl_ptr->Kill(context, req, resp);
+    return plugin_impl_ptr->Kill(context, req, resp);
 }
 
 Status PublisherImpl::GetConfigPolicy(ServerContext* context, const Empty* req,
                                       GetConfigPolicyReply* resp) {
-  try {
-   return plugin_impl_ptr->GetConfigPolicy(context, req, resp);
-  } catch (PluginException &e) {
-   resp->set_error(e.what());
-   return Status(StatusCode::UNKNOWN, e.what());
-  }
+    try {
+        return plugin_impl_ptr->GetConfigPolicy(context, req, resp);
+    } catch (PluginException &e) {
+        resp->set_error(e.what());
+        return Status(StatusCode::UNKNOWN, e.what());
+    }
 }
 
 Status PublisherImpl::Ping(ServerContext* context, const Empty* req,
                            ErrReply* resp) {
-  return plugin_impl_ptr->Ping(context, req, resp);
+    return plugin_impl_ptr->Ping(context, req, resp);
 }

--- a/src/snap/proxy/publisher_proxy.h
+++ b/src/snap/proxy/publisher_proxy.h
@@ -21,31 +21,29 @@ limitations under the License.
 #include "snap/proxy/plugin_proxy.h"
 
 namespace Plugin {
-namespace Proxy {
+    namespace Proxy {
+        class PublisherImpl final : public rpc::Publisher::Service {
+        public:
+            explicit PublisherImpl(Plugin::PublisherInterface* plugin);
 
-class PublisherImpl final : public rpc::Publisher::Service {
- public:
-  explicit PublisherImpl(Plugin::PublisherInterface* plugin);
+            ~PublisherImpl();
 
-  ~PublisherImpl();
+            grpc::Status Publish(grpc::ServerContext* context, const rpc::PubProcArg* req,
+                                rpc::ErrReply* resp);
 
-  grpc::Status Publish(grpc::ServerContext* context, const rpc::PubProcArg* req,
-                       rpc::ErrReply* resp);
+            grpc::Status Kill(grpc::ServerContext* context, const rpc::KillArg* request,
+                                rpc::ErrReply* response);
 
-  grpc::Status Kill(grpc::ServerContext* context, const rpc::KillArg* request,
-                    rpc::ErrReply* response);
+            grpc::Status GetConfigPolicy(grpc::ServerContext* context,
+                                        const rpc::Empty* request,
+                                        rpc::GetConfigPolicyReply* resp);
 
-  grpc::Status GetConfigPolicy(grpc::ServerContext* context,
-                               const rpc::Empty* request,
-                               rpc::GetConfigPolicyReply* resp);
+            grpc::Status Ping(grpc::ServerContext* context, const rpc::Empty* request,
+                                rpc::ErrReply* resp);
 
-  grpc::Status Ping(grpc::ServerContext* context, const rpc::Empty* request,
-                    rpc::ErrReply* resp);
-
- private:
-  Plugin::PublisherInterface* publisher;
-  PluginImpl* plugin_impl_ptr;
-};
-
-}  // namespace Proxy
+        private:
+            Plugin::PublisherInterface* publisher;
+            PluginImpl* plugin_impl_ptr;
+        };
+    }  // namespace Proxy
 }  // namespace Plugin

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,8 +22,8 @@ GTESTLIB_DIR	= $(CURDIR)/../googletest
 SNAPLIB_DIR	= $(CURDIR)/../lib
 PREFIX		= $(CURDIR)
 COV_ARGS	= -g -fprofile-arcs -ftest-coverage --coverage -fPIC -lgcov -O0
-CPPFLAGS	= --std=c++0x
-LDFLAGS		= --std=c++0x -fPIC -DPIC
+CPPFLAGS	= --std=c++1y
+LDFLAGS		= --std=c++1y -fPIC -DPIC
 SRCDIR		:= $(CURDIR)
 OBJDIR		:= $(CURDIR)
 SRC       	:= $(wildcard $(SRCDIR)/*.cc)
@@ -59,7 +59,7 @@ clean :
 init :	;
 	
 
-$(PREFIX)/$(EXE) : RUN_LDFLAGS = $(LDFLAGS) -L$(SNAPLIB_DIR)/lib -L$(GTESTLIB_DIR)/lib -pthread -lpthread -lgmock -lgtest -lsnap -lprotobuf -lgrpc++ -lgcov $(COV_ARGS)
+$(PREFIX)/$(EXE) : RUN_LDFLAGS = $(LDFLAGS) -L$(SNAPLIB_DIR)/lib -L$(GTESTLIB_DIR)/lib -pthread -lpthread -lgmock -lgtest -lsnap -lprotobuf -lgrpc++ -lgcov -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers $(COV_ARGS)
 $(PREFIX)/$(EXE) : $(OBJ)
 	$(run-ld)
 


### PR DESCRIPTION
--Created c++ flags class 
--Added command line options for standalone support
--Updated file extension
--Added command line flags to install with #include files
--Updated indentations and formatting to use 4 white spaces
--Updated formating and indentations to use 4 white spaces
--Added HeartbeatWatch support
--Added Flags class to source
--updated flags
--backing up work to rebuild
--Adding current devs to repo backup
--Adding cppnetlib support
--Checking in updated flags class and added http libs

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes # Add support for standalone plugin in cpp  

Summary of changes:
- Adds matching flags for c++ plugin
- Matches defaults of plugin-lib-go
- Matches plugin starting behavior for plugin-lib-go

How to verify it:
-compile example collector 'rando' to test added standalone capability

Testing done:
-verified successful build in Travis tests

A picture of a snapping turtle (not required but encouraged):
-