### PR TITLE
SDI-2695 Add TLS support to C++ Plugin library.

### DIFF
--- a/examples/collector/src/Makefile
+++ b/examples/collector/src/Makefile
@@ -27,7 +27,7 @@ CC=g++
 IDIRS=-I.
 LDIRS=-L.
 CFLAGS=-std=c++1y
-LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers -lz -lpthread -lssl -lcrypto
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers -lz -lpthread -lssl -lcrypto -lboost_filesystem
 FILES := $(wildcard *.cc)
 
 all: $(TARGET)				# Build all targets

--- a/examples/processor/src/Makefile
+++ b/examples/processor/src/Makefile
@@ -27,7 +27,7 @@ CC=g++
 IDIRS=-I.
 LDIRS=-L.
 CFLAGS=-std=c++1y
-LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers -lz -lpthread -lssl -lcrypto
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers -lz -lpthread -lssl -lcrypto -lboost_filesystem
 FILES := $(wildcard *.cc)
 
 all: $(TARGET)				# Build all targets

--- a/examples/publisher/src/Makefile
+++ b/examples/publisher/src/Makefile
@@ -27,7 +27,7 @@ CC=g++
 IDIRS=-I.
 LDIRS=-L.
 CFLAGS=-std=c++1y
-LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers -lz -lpthread -lssl -lcrypto
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers -lz -lpthread -lssl -lcrypto -lboost_filesystem
 FILES := $(wildcard *.cc)
 
 all: $(TARGET)				# Build all targets

--- a/src/snap/flags.h
+++ b/src/snap/flags.h
@@ -14,10 +14,12 @@ limitations under the License.
 #pragma once
 
 #include <boost/program_options.hpp>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <iterator>
+#include <map>
 #include <spdlog/spdlog.h>
+
 
 #define COMMAND_DESC "COMMANDS"
 #define GLOBAL_DESC "GLOBAL OPTIONS"
@@ -27,6 +29,7 @@ namespace po = boost::program_options;
 namespace spd = spdlog;
 
 using namespace std;
+
 
 namespace Plugin {
     //helper function to simplify main part
@@ -54,6 +57,7 @@ namespace Plugin {
         std::string _options_file, _listen_port, _listen_addr, _cert_path, _key_path, _root_cert_paths;
         int64_t _max_metrics_buffer;
 
+
     public:
         enum FlagType {
             Bool,
@@ -69,11 +73,11 @@ namespace Plugin {
         };
 
         Flags() {
-            _logger = spdlog::stdout_logger_mt("flags");
+            _logger = spdlog::stderr_logger_mt("flags");
         }
 
         Flags(const int &argc, char **argv) {
-            _logger = spdlog::stdout_logger_mt("flags");
+            _logger = spdlog::stderr_logger_mt("flags");
             this->SetFlags();
             this->ParseFlags(argc, argv);
         }
@@ -104,8 +108,10 @@ namespace Plugin {
         }
 
         int parseCommandLineFlags(const int &argc, char **argv);
+        int parsejsonFlags(const int &argc, char **argv);
         int parseConfigFileFlags(std::string filePathAndName = "");
         int ParseFlags(const int &argc, char **argv, std::string filePathAndName = "");
+
 
         void ShowVariablesMap();
         bool IsParsedFlag(const char *flagKey) { return _flags.count(flagKey); }

--- a/src/snap/grpc_export_impl.h
+++ b/src/snap/grpc_export_impl.h
@@ -21,10 +21,12 @@ limitations under the License.
 
 #include <grpc++/grpc++.h>
 #include <json.hpp>
+#include <spdlog/spdlog.h>
 
 #include "snap/config.h"
 #include "snap/metric.h"
 
+namespace spd = spdlog;
 #define RPC_VERSION 1
 
 namespace Plugin {
@@ -39,13 +41,20 @@ namespace Plugin {
         std::future<void> DoExport(std::shared_ptr<PluginInterface> plugin, const Meta* meta);
         struct handler_type;
 
+        GRPCExportImpl () {
+          _logger = spdlog::stderr_logger_mt("gprcExportImpl");
+        }
+
     protected:
         int port;
         std::shared_ptr<PluginInterface> plugin;
         const Meta* meta;
+        std::shared_ptr<grpc::ServerCredentials> credentials;
         std::unique_ptr<grpc::Service> service;
         std::unique_ptr<grpc::ServerBuilder> builder;
         std::unique_ptr<grpc::Server> server;
+
+        std::shared_ptr<grpc::ServerCredentials> configureCredentials();
 
         /* steps of the export procedure */
         void doConfigure();
@@ -56,5 +65,13 @@ namespace Plugin {
         void doJoin();
 
         int start_stand_alone(const int &httpPort);
+    private:
+        bool file_exists(const std::string);
+        std::string readFile(std::string);
+        std::string read_if_exists(std::string);
+        std::string load_key(std::string);
+        std::string load_directory(std::string);
+        std::string load_tls_ca(std::string);
+        std::shared_ptr<spd::logger> _logger;
     };
 }

--- a/src/snap/plugin.cc
+++ b/src/snap/plugin.cc
@@ -45,6 +45,7 @@ function<unique_ptr<Plugin::PluginExporter, function<void(Plugin::PluginExporter
 Plugin::PluginException::PluginException(const std::string& message) :
                                             runtime_error(message) {}
 
+
 Plugin::Meta::Meta(Type type, std::string name, int version) :
                     type(type),
                     name(name),
@@ -59,9 +60,9 @@ Plugin::Meta::Meta(Type type, std::string name, int version) :
                     listen_addr("127.0.0.1"),
                     pprof_enabled(false),
                     tls_enabled(false),
-                    cert_path(""),
-                    key_path(""),
-                    root_cert_paths("::"),
+                    tls_certificate_key_path(""),
+                    tls_certificate_crt_path(""),
+                    tls_certificate_authority_paths(""),
                     stand_alone(false),
                     stand_alone_port(stand_alone_port),
                     max_collect_duration(std::chrono::seconds(10)),
@@ -81,9 +82,9 @@ Plugin::Meta::Meta(Type type, std::string name, int version, Flags *flags) :
                     listen_addr(flags->GetFlagStrValue("addr")),
                     pprof_enabled(flags->IsParsedFlag("pprof")),
                     tls_enabled(flags->IsParsedFlag("tls")),
-                    cert_path(flags->GetFlagStrValue("cert-path")),
-                    key_path(flags->GetFlagStrValue("key-path")),
-                    root_cert_paths(flags->GetFlagStrValue("root-cert-paths")),
+                    tls_certificate_crt_path(flags->GetFlagStrValue("cert-path")),
+                    tls_certificate_key_path(flags->GetFlagStrValue("key-path")),
+                    tls_certificate_authority_paths(flags->GetFlagStrValue("root-cert-paths")),
                     stand_alone(flags->IsParsedFlag("stand-alone")),
                     stand_alone_port(flags->GetFlagIntValue("stand-alone-port")),
                     max_collect_duration(std::chrono::seconds(flags->GetFlagIntValue("max-collect-duration"))),

--- a/src/snap/plugin.h
+++ b/src/snap/plugin.h
@@ -26,7 +26,6 @@ limitations under the License.
 #define RPC_VERSION 1
 
 namespace Plugin {
-
     class CollectorInterface;
     class ProcessorInterface;
     class PublisherInterface;
@@ -150,17 +149,17 @@ namespace Plugin {
         /**
         * Necessary to provide when TLS enabled
         */
-        std::string cert_path;
+        std::string tls_certificate_crt_path;
 
         /**
         * Necessary to provide when TLS enabled
         */
-        std::string key_path;
+        std::string tls_certificate_key_path;
 
         /**
-        * Root path separator
+        * Neccessary to proivide when TLS Enabled. 
         */
-        std::string root_cert_paths;
+        std::string tls_certificate_authority_paths;
 
         /**
         * Enable stand-alone plugin
@@ -307,5 +306,4 @@ namespace Plugin {
     void start_collector(CollectorInterface* plg, const Meta& meta);
     void start_processor(ProcessorInterface* plg, const Meta& meta);
     void start_publisher(PublisherInterface* plg, const Meta& meta);
-
 };  // namespace Plugin

--- a/test/Makefile
+++ b/test/Makefile
@@ -59,7 +59,7 @@ clean :
 init :	;
 	
 
-$(PREFIX)/$(EXE) : RUN_LDFLAGS = $(LDFLAGS) -L$(SNAPLIB_DIR)/lib -L$(GTESTLIB_DIR)/lib -pthread -lpthread -lgmock -lgtest -lsnap -lprotobuf -lgrpc++ -lgcov -lboost_program_options -lboost_system -lboost_thread -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers $(COV_ARGS)
+$(PREFIX)/$(EXE) : RUN_LDFLAGS = $(LDFLAGS) -L$(SNAPLIB_DIR)/lib -L$(GTESTLIB_DIR)/lib -pthread -lpthread -lgmock -lgtest -lsnap -lprotobuf -lgrpc++ -lgcov -lboost_program_options -lboost_system -lboost_thread -lboost_filesystem -lcppnetlib-uri -lcppnetlib-client-connections -lcppnetlib-server-parsers $(COV_ARGS) 
 $(PREFIX)/$(EXE) : $(OBJ)
 	$(run-ld)
 

--- a/test/plugin_test.cc
+++ b/test/plugin_test.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "snap/metric.h"
 #include "../src/snap/lib_setup_impl.h"
 #include "gmock/gmock.h"
+#include "snap/flags.h"
 
 #include <functional>
 #include <memory>
@@ -159,4 +160,18 @@ TEST_F(PluginTest, StartPublisherInvokesExporterAndWaits) {
   EXPECT_EQ("average", actMeta->name);
   EXPECT_EQ(actPlugin, &publisher);
   EXPECT_EQ(true, completionCalled);
+}
+
+TEST_F(PluginTest, TestTLSVariables) {
+  int argc = 8;
+  char* argv[]{(char*)"this", (char*)"--tls", (char*)"--cert-path", (char*)"fake_path", (char*)"--key-path", (char*)"fake_path", (char*)"--root-cert-path", (char*)"fake_path"};
+  Plugin::Flags cli(argc, argv);
+
+  Plugin::Meta meta(Plugin::Collector, "average", 123, &cli);
+
+  EXPECT_EQ(meta.tls_enabled, true);
+
+  EXPECT_EQ(meta.tls_certificate_key_path, "fake_path");
+  EXPECT_EQ(meta.tls_certificate_crt_path, "fake_path");
+  EXPECT_EQ(meta.tls_certificate_authority_paths, "fake_path");
 }


### PR DESCRIPTION
Problem: Currently there is no encryption support within the C++ Plugin
library. This leaves data vulnerable to attack.

Solution: Utilize gRPC to add TLS encryption to library.

File Changes:
- examples/collector/src/Makefile
  Updated to link with ssl and crypto libraries.

- src/snap/grpc_export.cc
  Added functions for loading and reading the crt and key files.
  Added function for building gRPC Server Credentials
  Updated server to utilize encyption if provided.

- src/snap/grpc_export_impl.h
  Added definitions for configureCred() function and creds variable.

- src/snap/plugin.h
  Added variables to meta for storing cred values.

- src/snap/plugin.cc
  Added checks for environment variables for setting up cred values.

- test/plugin_test.cc
  Added tests to ensure meta variables are correctly set from
  environment.