### PR TITLE
Simpler creation of static and dynamic metrics

### DIFF
--- a/examples/collector/src/rando.cc
+++ b/examples/collector/src/rando.cc
@@ -30,6 +30,8 @@ using Plugin::Metric;
 using Plugin::Meta;
 using Plugin::Type;
 using Plugin::Flags;
+using Plugin::Namespace;
+using Plugin::NamespaceElement;
 
 using std::cout;
 using std::endl;
@@ -73,96 +75,13 @@ const ConfigPolicy Rando::get_config_policy() {
 }
 
 std::vector<Metric> Rando::get_metric_types(Config cfg) {
-    std::vector<Metric> metrics = {
-        {
-            {
-                {"intel", "", ""},
-                {"cpp", "", ""},
-                {"mock", "", ""},
-                {"randomnumber", "", ""},
-                {"float32", "", ""},
-            },
-            "",
-            "float32 random number"
-        },
-        {
-            {
-                {"intel", "", ""},
-                {"cpp", "", ""},
-                {"mock", "", ""},
-                {"randomnumber", "", ""},
-                {"float64", "", ""},
-            },
-            "",
-            "float64 random number"
-        },
-        {
-            {
-                {"intel", "", ""},
-                {"cpp", "", ""},
-                {"mock", "", ""},
-                {"randomnumber", "", ""},
-                {"int32", "", ""},
-            },
-            "",
-            "int32 random number"
-            },
-        {
-            {
-                {"intel", "", ""},
-                {"cpp", "", ""},
-                {"mock", "", ""},
-                {"randomnumber", "", ""},
-                {"int64", "", ""},
-            },
-            "",
-            "int64 random number"
-        },
-        {
-            {
-                {"intel", "", ""},
-                {"cpp", "", ""},
-                {"mock", "", ""},
-                {"randomnumber", "", ""},
-                {"uint32", "", ""},
-            },
-            "",
-            "uint32 random number"
-        },
-        {
-            {
-                {"intel", "", ""},
-                {"cpp", "", ""},
-                {"mock", "", ""},
-                {"randomnumber", "", ""},
-                {"uint64", "", ""},
-            },
-            "",
-            "uint64 random number"
-        },
-        {
-            {
-                {"intel", "", ""},
-                {"cpp", "", ""},
-                {"mock", "", ""},
-                {"randomboolean", "", ""},
-                {"boolean", "", ""},
-            },
-            "",
-            "random boolean"
-        },
-        {
-            {
-                {"intel", "", ""},
-                {"cpp", "", ""},
-                {"mock", "", ""},
-                {"randomstring", "", ""},
-                {"string", "", ""},
-            },
-            "",
-            "random string"
-        }
-    };
+
+    std::vector<Metric> metrics = { Metric(Namespace({"intel","cpp","mock","rando"}).add_static_element("int32"), "example_unit","example_description" ),
+                                    Metric(Namespace({"intel","cpp","mock","rando"}).add_static_element("int64"),"",""),
+                                    Metric(Namespace({"intel","cpp","mock","rando"}).add_static_element("string"),"",""),
+                                    Metric(Namespace({"intel","cpp","mock","rando"}).add_static_element("boolean"),"",""),
+                                    Metric(Namespace({"intel","cpp","mock","dynamic"}).add_dynamic_element("dynamo").add_static_element("string"),"",""),
+                                    };
     return metrics;
 }
 
@@ -171,8 +90,8 @@ void Rando::collect_metrics(std::vector<Metric> &metrics) {
     unsigned int seed = time(NULL);
     int random_value = rand_r(&seed) % 1000;
 
-    for (mets_iter = metrics.begin(); mets_iter != metrics.end(); mets_iter++) {
-        std::string ns_mts_type = mets_iter->ns()[4].value;
+    for (mets_iter = metrics.begin(); mets_iter != metrics.end(); ++mets_iter) {
+        std::string ns_mts_type = mets_iter->ns()[4].get_value();
         int mts_type = metric_types[ns_mts_type];
 
         switch(mts_type) {

--- a/examples/publisher/src/log.cc
+++ b/examples/publisher/src/log.cc
@@ -35,6 +35,8 @@ using Plugin::Metric;
 using Plugin::Meta;
 using Plugin::Type;
 using Plugin::Flags;
+using Plugin::Namespace;
+using Plugin::NamespaceElement;
 
 const ConfigPolicy Log::get_config_policy() {
     ConfigPolicy policy(Plugin::StringRule{
@@ -66,8 +68,8 @@ void Log::publish_metrics(std::vector<Metric> &metrics,
         }
 
         // namespace
-        for (Metric::NamespaceElement nse : mets_iter->ns()) {
-            outfile << "/" << nse.value;
+        for ( NamespaceElement nse : mets_iter->ns().get_namespace_elements()) {
+            outfile << "/" << nse.get_value();
         }
 
         // tags

--- a/examples/task.json
+++ b/examples/task.json
@@ -8,7 +8,11 @@
 	"workflow":{
 		"collect":{
 			"metrics":{
-				"/intel/cpp/mock/*":{}
+				"/intel/cpp/mock/rando/int32":{},
+ 				"/intel/cpp/mock/rando/string":{},
+ 				"/intel/cpp/mock/rando/int64":{},
+ 				"/intel/cpp/mock/rando/boolean":{},
+ 				"/intel/cpp/mock/dynamic/*/string":{}
 			},
 			"config":{
 				"/intel/cpp/mock/randomnumber/one":{
@@ -34,4 +38,3 @@
 		}
 	}
 }
-

--- a/scripts/small.sh
+++ b/scripts/small.sh
@@ -40,7 +40,7 @@ export SNAPLIB_DIR="${__proj_dir}/lib"
 mkdir -p "${SNAPLIB_DIR}"
 pushd "${__proj_dir}"
 "${__proj_dir}/autogen.sh"
-"${__proj_dir}/configure" CPPFLAGS="--std=c++0x ${COV_ARGS}" LDFLAGS="${COV_ARGS}"  --prefix="${SNAPLIB_DIR}"
+"${__proj_dir}/configure" CPPFLAGS="--std=c++1y ${COV_ARGS}" LDFLAGS="${COV_ARGS}"  --prefix="${SNAPLIB_DIR}"
 make -C "${__proj_dir}"
 make -C "${__proj_dir}" install
 popd

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -28,6 +28,8 @@ using Plugin::Config;
 using Plugin::Metric;
 using Plugin::ConfigPolicy;
 using Plugin::StringRule;
+using Plugin::Namespace;
+using Plugin::NamespaceElement;
 
 class MockCollector : public Plugin::CollectorInterface {
 public:
@@ -38,14 +40,7 @@ public:
       }
   }};
 
-  Metric fake_metric{
-      {
-          {"foo", "", ""},
-          {"bar", "", ""},
-      },
-      "",
-      "critical metric"
-  };
+  Metric fake_metric{ Namespace { {"foo","bar"}}, "" , ""};
 
   MOCK_METHOD0(get_config_policy, const ConfigPolicy());
   MOCK_METHOD1(get_metric_types, std::vector<Metric>(Config cfg));
@@ -61,14 +56,7 @@ public:
       }
   }};
 
-  Metric fake_metric{
-      {
-          {"foo", "", ""},
-          {"bar", "", ""},
-      },
-      "",
-      "critical metric"
-  };
+  Metric fake_metric{ Namespace { {"foo","bar"}}, "" , ""};
 
   MOCK_METHOD0(get_config_policy, const ConfigPolicy());
   MOCK_METHOD2(process_metrics, void(std::vector<Plugin::Metric> &metrics, const Plugin::Config& config));
@@ -83,14 +71,8 @@ public:
       }
   }};
 
-  Metric fake_metric{
-      {
-          {"foo", "", ""},
-          {"bar", "", ""},
-      },
-      "",
-      "critical metric"
-  };
+  Metric fake_metric{ Namespace { {"foo","bar"}}, "" , ""};
+
 
   MOCK_METHOD0(get_config_policy, const ConfigPolicy());
   MOCK_METHOD2(publish_metrics, void(std::vector<Plugin::Metric> &metrics, const Plugin::Config& config));


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #39



Summary of changes:
-Two classes: Namespace and Namespace_Element with getters, setters and basic encapsulation,
-Simpler creation of metrics.

    New way:

    std::vector<Metric> metrics = { Metric(Namespace({"intel","cpp","mock","rando"}).add_static_element("int32"), "example_unit","example_description" ),
                                    Metric(Namespace({"intel","cpp","mock","rando"}).add_static_element("int64"),"",""),
                                    Metric(Namespace({"intel","cpp","mock","rando"}).add_static_element("string"),"",""),
                                    Metric(Namespace({"intel","cpp","mock","rando"}).add_static_element("boolean"),"",""),
                                    Metric(Namespace({"intel","cpp","mock","dynamic"}).add_dynamic_element("[dynamo]").add_static_element("string"),"",""),
                                    };


    Old way:

    std::vector<Metric> metrics = {
        {
            {
                {"intel", "", ""},
                {"cpp", "", ""},
                {"mock", "", ""},
                {"randomnumber", "", ""},
                {"float32", "", ""},
            },
            "",
            "float32 random number"
        },


How to verify it:
- Run example collector inside task and watch it (WARNING: collector does not cover dynamic metrics!).

Testing done:
- New methods have been tested in metric_test.cc

A picture of a snapping turtle:

![snapik](https://user-images.githubusercontent.com/22373844/28865019-b3ce697c-776e-11e7-8826-70daaaaea3e7.png)
