### PR TITLE
Modify collect metrics

### DIFF
--- a/examples/collector/src/rando.cc
+++ b/examples/collector/src/rando.cc
@@ -85,7 +85,7 @@ std::vector<Metric> Rando::get_metric_types(Config cfg) {
     return metrics;
 }
 
-void Rando::collect_metrics(std::vector<Metric> &metrics) {
+std::vector<Metric> Rando::collect_metrics(std::vector<Metric> &metrics) {
     std::vector<Metric>::iterator mets_iter;
     unsigned int seed = time(NULL);
     int random_value = rand_r(&seed) % 1000;
@@ -122,6 +122,8 @@ void Rando::collect_metrics(std::vector<Metric> &metrics) {
         }
         mets_iter->set_timestamp();
     }
+    std::vector<Metric> result_metrics = metrics;
+    return result_metrics;
 }
 
 int main(int argc, char **argv) {

--- a/examples/collector/src/rando.h
+++ b/examples/collector/src/rando.h
@@ -25,5 +25,5 @@ class Rando final : public Plugin::CollectorInterface {
     public:
     const Plugin::ConfigPolicy get_config_policy();
     std::vector<Plugin::Metric> get_metric_types(Plugin::Config cfg);
-    void collect_metrics(std::vector<Plugin::Metric> &metrics);
+    std::vector<Plugin::Metric> collect_metrics(std::vector<Plugin::Metric> &metrics);
 };

--- a/examples/task.json
+++ b/examples/task.json
@@ -12,11 +12,14 @@
  				"/intel/cpp/mock/rando/string":{},
  				"/intel/cpp/mock/rando/int64":{},
  				"/intel/cpp/mock/rando/boolean":{},
- 				"/intel/cpp/mock/dynamic/*/string":{}
+ 				"/intel/cpp/mock/dynamic/*/int64":{}
 			},
 			"config":{
 				"/intel/cpp/mock/randomnumber/one":{
 					"password":"silly goose"
+				},
+				"/intel/cpp/mock/dynamic/*/int64":{
+					"dynamic_count":10
 				}
 			},
 			"process":[

--- a/src/snap/metric.cc
+++ b/src/snap/metric.cc
@@ -278,6 +278,10 @@ const NamespaceElement Namespace::operator[] (int index) const {
     return namespace_elements[index];
 }
 
+NamespaceElement& Namespace::operator[] (int index) {
+    return namespace_elements[index];
+}
+
 Namespace& Namespace::add_static_element(std::string value){
     this->namespace_elements.push_back(NamespaceElement(value));
     return *this;

--- a/src/snap/metric.h
+++ b/src/snap/metric.h
@@ -107,10 +107,12 @@ namespace Plugin {
         ~Namespace();
 
         /**
-        * Overloaded range operator. It returns "NamespaceElement" object
+        * Overloaded range operators. They return "NamespaceElement" object
         * from given index.
         */
         const NamespaceElement operator[] (int index) const;
+
+        NamespaceElement& operator[] (int index);
 
         /**
         *  add_static_element adds a static element to the Namespace.  A static

--- a/src/snap/metric.h
+++ b/src/snap/metric.h
@@ -213,7 +213,6 @@ namespace Plugin {
         Metric(Namespace &&ns, std::string unit,
                 std::string description);
 
-
         /**
         * This constructor is used in the plugin proxies.
         * It's used to wrap the rpc::Metric and rpc::ConfigMap types with the metric

--- a/src/snap/plugin.h
+++ b/src/snap/plugin.h
@@ -264,7 +264,7 @@ namespace Plugin {
         * collect_metrics is given a list of metrics to collect.
         * It should collect and annotate each metric with the apropos context.
         */
-        virtual void collect_metrics(std::vector<Metric> &metrics) = 0;
+        virtual std::vector<Metric> collect_metrics(std::vector<Metric> &metrics) = 0;
     };
 
     /**

--- a/src/snap/proxy/collector_proxy.cc
+++ b/src/snap/proxy/collector_proxy.cc
@@ -59,9 +59,9 @@ Status CollectorImpl::CollectMetrics(ServerContext* context,
     }
 
     try {
-        collector->collect_metrics(metrics);
+        std::vector<Metric> result_metrics = collector->collect_metrics(metrics);
 
-        for (Metric met : metrics) {
+        for (Metric met : result_metrics) {
             *resp->add_metrics() = *met.get_rpc_metric_ptr();
         }
         return Status::OK;

--- a/test/collectorproxy_test.cc
+++ b/test/collectorproxy_test.cc
@@ -81,6 +81,8 @@ TEST(CollectorProxySuccessTest, CollectMetricsWorks) {
             metrics.at(i).set_data(data);
             report.emplace_back(metrics.at(i));
         }
+        vector<Metric> result = metrics;
+        return result;
     };
 
     ON_CALL(mockee, collect_metrics(_))

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -44,7 +44,7 @@ public:
 
   MOCK_METHOD0(get_config_policy, const ConfigPolicy());
   MOCK_METHOD1(get_metric_types, std::vector<Metric>(Config cfg));
-  MOCK_METHOD1(collect_metrics, void(std::vector<Metric> &metrics));
+  MOCK_METHOD1(collect_metrics, std::vector<Metric>(std::vector<Metric> &metrics));
 };
 
 class MockProcessor : public Plugin::ProcessorInterface {


### PR DESCRIPTION

Fixes:
- #52
- #40

Summary of changes:
- collect_metrics now returns vector of metrics just like in [lib-go](https://github.com/intelsdi-x/snap-plugin-lib-go),
- example collector plugin now covers dynamic metrics

How to verify it:
- run example task included inside examples/task.json

