### PR TITLE
Fix TLS enabled by default

### DIFF
--- a/src/snap/flags.cc
+++ b/src/snap/flags.cc
@@ -384,6 +384,8 @@ json Plugin::JsonHelpers::removeUnusedFlags(json j) {
       error << "Key provided but not supported: " << it.key() << std::endl;
       _logger->error(error.str());
       notFlag.push_back(it.key());
+    } else if (it.value().is_boolean() && !it.value()) {
+      notFlag.push_back(it.key());
     }
   }
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #57 

Summary of changes:
- Fixed parsing incoming JSON data into command line flags - remove flags if bool JSON param value is false.

How to verify it:
- Load plugin without flags - plugin should now load successfully
- Load plugin with tls parameters passed - plugin should use TLS

Testing done:
- Manual

A picture of a snapping turtle (not required but encouraged):
-
