### PR TITLE
Fixes #60, moved parsing of flags and printing of version from plugin main() to snap-plugin-lib

### DIFF
--- a/examples/collector/README.md
+++ b/examples/collector/README.md
@@ -85,7 +85,7 @@ The interface is slightly different depending on what type (collector, processor
 After implementing a type that satisfies one of {collector, processor, publisher} interfaces, all that is left to do is to call the appropriate plugin.start_xxx() with your plugin specific meta options. For example with minimum meta data specified:
 
 ```cpp
-    Plugin::start_collector(&plg, Meta{Type::Collector, "rando", 1});
+    Plugin::start_collector(argc, argv, &plg, Meta{Type::Collector, "rando", 1});
 ```
 
 ### Meta options
@@ -144,10 +144,9 @@ struct Meta final {
 An example using some arbitrary values:
 
 ```cpp
-    Rando plg = Rando();
-    Meta meta = Meta{Type::Collector, "rando", 1};
-    meta.exclusive = true;
-    Plugin::start_collector(&plg, meta);
+    Meta meta(Type::Collector, "rando", 1);
+    Rando plg;
+    start_collector(argc, argv, &plg, meta);
 ```
 
 ## Testing

--- a/examples/collector/src/rando.cc
+++ b/examples/collector/src/rando.cc
@@ -144,14 +144,8 @@ std::vector<Metric> Rando::collect_metrics(std::vector<Metric> &metrics) {
 }
 
 int main(int argc, char **argv) {
-    Flags cli(argc, argv);
-    Meta meta(Type::Collector, "rando", 1, &cli);
 
-    if (cli.IsParsedFlag("version")) {
-        cout << meta.name << " version "  << meta.version << endl;
-        exit(0);
-    }
-
+    Meta meta(Type::Collector, "rando", 1);
     Rando plg;
-    start_collector(&plg, meta);
+    start_collector(argc, argv, &plg, meta);
 }

--- a/examples/processor/README.md
+++ b/examples/processor/README.md
@@ -77,7 +77,7 @@ The interface is slightly different depending on what type (collector, processor
 After implementing a type that satisfies one of {collector, processor, publisher} interfaces, all that is left to do is to call the appropriate plugin.start_xxx() with your plugin specific meta options. For example with minimum meta data specified:
 
 ```cpp
-    Plugin::start_processor(&plg, Meta{Type::Processor, "graffiti", 1});
+    Plugin::start_processor(argc, argv, &plg, Meta{Type::Processor, "graffiti", 1});
 ```
 
 ### Meta options
@@ -136,10 +136,9 @@ struct Meta final {
 An example using some arbitrary values:
 
 ```cpp
+    Meta meta(Type::Processor, "graffiti", 1);
     Graffiti plg = Graffiti();
-    Meta meta = Meta{Type::Collector, "graffiti", 1};
-    meta.exclusive = true;
-    Plugin::start_processor(&plg, meta);
+    start_processor(argc, argv, &plg, meta);
 ```
 
 ## Testing

--- a/examples/processor/src/graffiti.cc
+++ b/examples/processor/src/graffiti.cc
@@ -55,14 +55,10 @@ void Graffiti::process_metrics(std::vector<Metric> &metrics,
 }
 
 int main(int argc, char **argv) {
-    Flags cli(argc, argv);
-    Meta meta(Type::Processor, "graffiti", 1, &cli);
-    if (cli.IsParsedFlag("version")) {
-        cout << meta.name << " version "  << meta.version << endl;
-        exit(0);
-    }
+
+    Meta meta(Type::Processor, "graffiti", 1);
     Graffiti plg = Graffiti();
-    start_processor(&plg, meta);
+    start_processor(argc, argv, &plg, meta);
 }
 
 

--- a/examples/publisher/README.md
+++ b/examples/publisher/README.md
@@ -77,7 +77,7 @@ The interface is slightly different depending on what type (collector, processor
 After implementing a type that satisfies one of {collector, processor, publisher} interfaces, all that is left to do is to call the appropriate plugin.start_xxx() with your plugin specific meta options. For example with minimum meta data specified:
 
 ```cpp
-    Plugin::start_publisher(&plg, Meta{Type::Publisher, "log", 1});
+    Plugin::start_publisher(argc, argv, &plg, Meta{Type::Publisher, "log", 1});
 ```
 
 ### Meta options
@@ -136,10 +136,9 @@ struct Meta final {
 An example using some arbitrary values:
 
 ```cpp
+    Meta meta(Type::Publisher, "log", 1);
     Log plg = Log();
-    Meta meta = Meta{Type::Publisher, "log", 1};
-    meta.exclusive = true;
-    Plugin::start_publisher(&plg, meta);
+    start_publisher(argc, argv, &plg, meta);
 ```
 
 ## Testing

--- a/examples/publisher/src/log.cc
+++ b/examples/publisher/src/log.cc
@@ -120,12 +120,8 @@ void Log::publish_metrics(std::vector<Metric> &metrics,
 }
 
 int main(int argc, char **argv) {
-    Flags cli(argc, argv);
-    Meta meta(Type::Publisher, "log", 1, &cli);
-    if (cli.IsParsedFlag("version")) {
-        cout << meta.name << " version "  << meta.version << endl;
-        exit(0);
-    }
+
+    Meta meta(Type::Publisher, "log", 1);
     Log plg = Log();
-    start_publisher(&plg, meta);
+    start_publisher(argc, argv, &plg, meta);
 }

--- a/src/snap/flags.h
+++ b/src/snap/flags.h
@@ -77,7 +77,8 @@ namespace Plugin {
         }
 
         Flags(const int &argc, char **argv) {
-            _logger = spdlog::stderr_logger_mt("flags");
+            std::string logger_name = argc > 0 ? "flags_" + std::string(argv[0]) : "flags";
+            _logger = spdlog::stderr_logger_mt(logger_name);
             this->SetFlags();
             this->ParseFlags(argc, argv);
         }

--- a/src/snap/plugin.cc
+++ b/src/snap/plugin.cc
@@ -68,27 +68,20 @@ Plugin::Meta::Meta(Type type, std::string name, int version) :
                     max_collect_duration(std::chrono::seconds(10)),
                     max_metrics_buffer(0) {}
 
-Plugin::Meta::Meta(Type type, std::string name, int version, Flags *flags) :
-                    type(type),
-                    name(name),
-                    version(version),
-                    rpc_type(RpcType::GRPC),
-                    concurrency_count(5),
-                    exclusive(false),
-                    unsecure(true),
-                    cache_ttl(std::chrono::milliseconds(500)),
-                    strategy(Strategy::LRU),
-                    listen_port(flags->GetFlagStrValue("port")),
-                    listen_addr(flags->GetFlagStrValue("addr")),
-                    pprof_enabled(flags->IsParsedFlag("pprof")),
-                    tls_enabled(flags->IsParsedFlag("tls")),
-                    tls_certificate_crt_path(flags->GetFlagStrValue("cert-path")),
-                    tls_certificate_key_path(flags->GetFlagStrValue("key-path")),
-                    tls_certificate_authority_paths(flags->GetFlagStrValue("root-cert-paths")),
-                    stand_alone(flags->IsParsedFlag("stand-alone")),
-                    stand_alone_port(flags->GetFlagIntValue("stand-alone-port")),
-                    max_collect_duration(std::chrono::seconds(flags->GetFlagIntValue("max-collect-duration"))),
-                    max_metrics_buffer(flags->GetFlagInt64Value("max-metrics-buffer")) {}
+
+void Plugin::Meta::use_cli_args(Flags *flags) {
+	listen_port = flags->GetFlagStrValue("port");
+	listen_addr = flags->GetFlagStrValue("addr");
+	pprof_enabled = flags->IsParsedFlag("pprof");
+	tls_enabled = flags->IsParsedFlag("tls");
+	tls_certificate_crt_path = flags->GetFlagStrValue("cert-path");
+	tls_certificate_key_path = flags->GetFlagStrValue("key-path");
+	tls_certificate_authority_paths = flags->GetFlagStrValue("root-cert-paths");
+	stand_alone = flags->IsParsedFlag("stand-alone");
+	stand_alone_port = flags->GetFlagIntValue("stand-alone-port");
+	max_collect_duration = std::chrono::seconds(flags->GetFlagIntValue("max-collect-duration"));
+	max_metrics_buffer = flags->GetFlagInt64Value("max-metrics-buffer");
+}
 
 Plugin::CollectorInterface* Plugin::PluginInterface::IsCollector() {
     return nullptr;
@@ -126,18 +119,42 @@ Plugin::PublisherInterface* Plugin::PublisherInterface::IsPublisher() {
     return this;
 }
 
-void Plugin::start_collector(CollectorInterface* collector,
-                             const Meta& meta) {
+void Plugin::start_collector(int argc, char **argv, CollectorInterface* collector,
+                             Meta& meta) {
+    Flags cli(argc, argv);
+    meta.use_cli_args(&cli);
+
+    if (cli.IsParsedFlag("version")) {
+        cout << meta.name << " version "  << meta.version << endl;
+        exit(0);
+    }
+
     start_plugin(collector, meta);
 }
 
-void Plugin::start_processor(ProcessorInterface* processor,
-                             const Meta& meta) {
+void Plugin::start_processor(int argc, char **argv, ProcessorInterface* processor,
+                             Meta& meta) {
+    Flags cli(argc, argv);
+    meta.use_cli_args(&cli);
+
+    if (cli.IsParsedFlag("version")) {
+        cout << meta.name << " version "  << meta.version << endl;
+        exit(0);
+    }
+
     start_plugin(processor, meta);
 }
 
-void Plugin::start_publisher(PublisherInterface* publisher,
-                             const Meta& meta) {
+void Plugin::start_publisher(int argc, char **argv, PublisherInterface* publisher,
+                             Meta& meta) {
+    Flags cli(argc, argv);
+    meta.use_cli_args(&cli);
+
+    if (cli.IsParsedFlag("version")) {
+        cout << meta.name << " version "  << meta.version << endl;
+        exit(0);
+    }
+
     start_plugin(publisher, meta);
 }
 

--- a/src/snap/plugin.h
+++ b/src/snap/plugin.h
@@ -76,7 +76,7 @@ namespace Plugin {
     /**
     * Meta is the metadata about the plugin.
     */
-    struct Meta final {
+    class Meta final {
     public:
         Meta(Type type, std::string name, int version);
         Meta(Type type, std::string name, int version, Flags *flags);
@@ -184,6 +184,11 @@ namespace Plugin {
         * Defaults to zero what means send metrics immediately
         */
         int64_t max_metrics_buffer;
+
+        /**
+        * use_cli_args updates plugin meta using arguments from cli
+        */
+        void use_cli_args(Flags *flags);
     };
 
     /**
@@ -303,7 +308,7 @@ namespace Plugin {
     * These functions do not manage the plugin instance passed as parameter -
     * caller's responsible for releasing the resources.
     */
-    void start_collector(CollectorInterface* plg, const Meta& meta);
-    void start_processor(ProcessorInterface* plg, const Meta& meta);
-    void start_publisher(PublisherInterface* plg, const Meta& meta);
+    void start_collector(int argc, char **argv, CollectorInterface* plg, Meta& meta);
+    void start_processor(int argc, char **argv, ProcessorInterface* plg, Meta& meta);
+    void start_publisher(int argc, char **argv, PublisherInterface* plg, Meta& meta);
 };  // namespace Plugin

--- a/test/plugin_test.cc
+++ b/test/plugin_test.cc
@@ -110,7 +110,10 @@ TEST_F(PluginTest, StartCollectorInvokesExporterAndWaits) {
     .WillByDefault(Invoke(reporter));
   Plugin::LibSetup::exporter_provider = [&]{
     return unique_ptr<Plugin::PluginExporter, function<void(Plugin::PluginExporter*)>>(&exporter, [](Plugin::PluginExporter*){}); };
-  Plugin::start_collector(&collector, meta);
+
+  int argc = 1;
+  char* argv[]{(char*)"this"};
+  Plugin::start_collector(argc, argv, &collector, meta);
 
   EXPECT_EQ("average", actMeta->name);
   EXPECT_EQ(actPlugin, &collector);
@@ -133,7 +136,10 @@ TEST_F(PluginTest, StartProcessorInvokesExporterAndWaits) {
     .WillByDefault(Invoke(reporter));
   Plugin::LibSetup::exporter_provider = [&]{
     return unique_ptr<Plugin::PluginExporter, function<void(Plugin::PluginExporter*)>>(&exporter, [](Plugin::PluginExporter*){}); };
-  Plugin::start_processor(&processor, meta);
+
+  int argc = 1;
+  char* argv[]{(char*)"this"};
+  Plugin::start_processor(argc, argv, &processor, meta);
 
   EXPECT_EQ("average", actMeta->name);
   EXPECT_EQ(actPlugin, &processor);
@@ -155,7 +161,10 @@ TEST_F(PluginTest, StartPublisherInvokesExporterAndWaits) {
     .WillByDefault(Invoke(reporter));
   Plugin::LibSetup::exporter_provider = [&]{
     return unique_ptr<Plugin::PluginExporter, function<void(Plugin::PluginExporter*)>>(&exporter, [](Plugin::PluginExporter*){}); };
-  Plugin::start_publisher(&publisher, meta);
+
+  int argc = 1;
+  char* argv[]{(char*)"this"};
+  Plugin::start_publisher(argc, argv, &publisher, meta);
 
   EXPECT_EQ("average", actMeta->name);
   EXPECT_EQ(actPlugin, &publisher);
@@ -167,7 +176,8 @@ TEST_F(PluginTest, TestTLSVariables) {
   char* argv[]{(char*)"this", (char*)"--tls", (char*)"--cert-path", (char*)"fake_path", (char*)"--key-path", (char*)"fake_path", (char*)"--root-cert-path", (char*)"fake_path"};
   Plugin::Flags cli(argc, argv);
 
-  Plugin::Meta meta(Plugin::Collector, "average", 123, &cli);
+  Plugin::Meta meta(Plugin::Collector, "average", 123);
+  meta.use_cli_args(&cli);
 
   EXPECT_EQ(meta.tls_enabled, true);
 

--- a/test/plugin_test.cc
+++ b/test/plugin_test.cc
@@ -112,7 +112,7 @@ TEST_F(PluginTest, StartCollectorInvokesExporterAndWaits) {
     return unique_ptr<Plugin::PluginExporter, function<void(Plugin::PluginExporter*)>>(&exporter, [](Plugin::PluginExporter*){}); };
 
   int argc = 1;
-  char* argv[]{(char*)"this"};
+  char* argv[]{(char*)"collector-plugin"};
   Plugin::start_collector(argc, argv, &collector, meta);
 
   EXPECT_EQ("average", actMeta->name);
@@ -138,7 +138,7 @@ TEST_F(PluginTest, StartProcessorInvokesExporterAndWaits) {
     return unique_ptr<Plugin::PluginExporter, function<void(Plugin::PluginExporter*)>>(&exporter, [](Plugin::PluginExporter*){}); };
 
   int argc = 1;
-  char* argv[]{(char*)"this"};
+  char* argv[]{(char*)"processor-plugin"};
   Plugin::start_processor(argc, argv, &processor, meta);
 
   EXPECT_EQ("average", actMeta->name);
@@ -163,7 +163,7 @@ TEST_F(PluginTest, StartPublisherInvokesExporterAndWaits) {
     return unique_ptr<Plugin::PluginExporter, function<void(Plugin::PluginExporter*)>>(&exporter, [](Plugin::PluginExporter*){}); };
 
   int argc = 1;
-  char* argv[]{(char*)"this"};
+  char* argv[]{(char*)"publisher-plugin"};
   Plugin::start_publisher(argc, argv, &publisher, meta);
 
   EXPECT_EQ("average", actMeta->name);


### PR DESCRIPTION
Fixes #60

Summary of changes:
-  moved parsing of flags and printing of version from plugin main() to snap-plugin-lib

This change is needed for plugin diagnostics and streaming features.
 Before only `Meta` has an "access" to arguments from cli, diagnostics and streaming require to have an "access" to arguments from cli.

How to verify it:
- load plugins and create task

Testing done:
- manual tests, small test

